### PR TITLE
Status pages fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-require("./lib/peon")();
+require('./lib/peon')()

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -163,7 +163,10 @@ class Dispatcher {
 
       for (let key in peonConfig.environment || {}) {
         peonConfig.environment[key] = peonConfig.environment[key]
-          .replace('$PEON_ROOT_URL', join(rootURLBase, repoName))
+          .replace(
+            '$PEON_ROOT_URL',
+            join(rootURLBase, repoName, repoConfig.branch)
+          )
           .replace('$PEON_BRANCH', repoConfig.branch)
       }
 

--- a/lib/peon.js
+++ b/lib/peon.js
@@ -6,8 +6,11 @@ const { extractRepoName } = require('./utils')
 const Watcher = require('./watcher')
 const Dispatcher = require('./dispatcher')
 const webhooks = require('./webhooks')
+const status = require('./status')
 
-module.exports = function() {
+module.exports = async function() {
+  await status.init()
+
   let dispatcher = new Dispatcher()
 
   if (watcherEnabled) {

--- a/lib/status.js
+++ b/lib/status.js
@@ -75,7 +75,12 @@ async function renderStatus(now) {
             'peon-status',
             `${buildId.replace(/#/, '-')}.html`
           ),
-          compiled.build(Object.assign(build, { buildId }))
+          compiled.build(
+            Object.assign(build, {
+              buildId,
+              isRunning: ['pending', 'running'].indexOf(build.status) !== -1
+            })
+          )
         )
       }
     }
@@ -113,7 +118,7 @@ async function renderStatus(now) {
   logger.debug('rendering index', { module: 'status/render' })
   await writeFile(
     resolve(publicDirectory, 'index.html'),
-    compiled.index({ repos: status })
+    compiled.index({ repos: status, now })
   )
 
   logger.debug('writing render info', { module: 'status/render' })

--- a/lib/status.js
+++ b/lib/status.js
@@ -7,28 +7,6 @@ const logger = require('./logger')
 
 const statusRoot = resolve(workingDirectory, 'peon-status')
 
-/* Locking mechanism */
-
-const locks = {}
-
-function acquireLock(lock) {
-  function tryAcquire(lock, then) {
-    if (locks[lock]) {
-      setTimeout(() => tryAcquire(lock, then), 1000)
-    } else {
-      locks[lock] = true
-      setTimeout(then, 0)
-    }
-  }
-  return new Promise((resolve) => tryAcquire(lock, resolve))
-}
-
-function releaseLock(lock) {
-  locks[lock] = false
-}
-
-/* Templating/rendering */
-
 Handlebars.registerHelper('date', function(timestamp) {
   return new Date(timestamp).toISOString()
 })
@@ -83,10 +61,11 @@ async function renderStatus(now) {
 
   for (let repo in status) {
     let repoStatus = status[repo]
+    let { builds } = repoStatus
 
     // Render builds that were updated since last render
-    for (let buildId in repoStatus.builds) {
-      let build = repoStatus.builds[buildId]
+    for (let buildId in builds) {
+      let build = builds[buildId]
 
       if (build.updated > lastRender) {
         logger.debug(`rendering build ${buildId}`, { module: 'status/render' })
@@ -102,12 +81,12 @@ async function renderStatus(now) {
     }
 
     // Crunch data for index
-    repoStatus.lastBuilds = Object.keys(repoStatus.builds)
+    repoStatus.lastBuilds = Object.keys(builds)
       .sort()
       .reverse()
       .slice(0, 10)
       .map((buildId) =>
-        Object.assign(repoStatus.builds[buildId], {
+        Object.assign(builds[buildId], {
           buildId,
           link: `peon-status/${buildId.replace(/#/, '-')}.html`
         })
@@ -115,9 +94,9 @@ async function renderStatus(now) {
 
     let builtBranches = [
       ...new Set(
-        Object.keys(repoStatus.builds)
-          .filter((buildId) => repoStatus.builds[buildId].status === 'success')
-          .map((buildId) => repoStatus.builds[buildId].branch)
+        Object.keys(builds)
+          .filter((buildId) => builds[buildId].status === 'success')
+          .map((buildId) => builds[buildId].branch)
       )
     ].sort()
 
@@ -140,54 +119,40 @@ async function renderStatus(now) {
   logger.debug('writing render info', { module: 'status/render' })
   renderInfo.lastRender = now
   await writeFile(renderInfoFile, JSON.stringify(renderInfo))
+
+  logger.info('updated status pages', { module: 'status/render' })
 }
 
-/* Locked repo status updates */
-
 async function updateRepoStatus(repoName, updater) {
-  let ret
+  let ret, repoStatus
   let now = Date.now()
 
-  await acquireLock(repoName)
+  let statusFile = resolve(statusRoot, `${repoName}.json`)
+
   try {
-    let statusFile = resolve(statusRoot, `${repoName}.json`)
-
-    try {
-      await mkdir(statusRoot, { recursive: true })
-    } catch(e) {
-      if (e.code !== 'EEXIST') {
-        throw e
-      }
+    await mkdir(statusRoot, { recursive: true })
+  } catch(e) {
+    if (e.code !== 'EEXIST') {
+      throw e
     }
-
-    let repoStatus
-    try {
-      repoStatus = JSON.parse(await readFile(statusFile))
-    } catch(e) {
-      repoStatus = {
-        nextBuildNum: 1,
-        builds: {}
-      }
-    }
-
-    ret = updater(repoStatus, now)
-
-    await writeFile(statusFile, JSON.stringify(repoStatus))
-  } finally {
-    releaseLock(repoName)
   }
 
-  await acquireLock('peon-status')
   try {
-    await renderStatus(now)
-  } finally {
-    releaseLock('peon-status')
+    repoStatus = JSON.parse(await readFile(statusFile))
+  } catch(e) {
+    repoStatus = {
+      nextBuildNum: 1,
+      builds: {}
+    }
   }
+
+  ret = updater(repoStatus, now)
+
+  await writeFile(statusFile, JSON.stringify(repoStatus))
+  await renderStatus(now)
 
   return ret
 }
-
-/* Public interface */
 
 module.exports = {
   // Returns buildId

--- a/lib/status.js
+++ b/lib/status.js
@@ -51,14 +51,6 @@ async function renderStatus(now) {
     )
   }
 
-  try {
-    await mkdir(resolve(publicDirectory, 'peon-status'), { recursive: true })
-  } catch(e) {
-    if (e.code !== 'EEXIST') {
-      throw e
-    }
-  }
-
   for (let repo in status) {
     let repoStatus = status[repo]
     let { builds } = repoStatus
@@ -165,6 +157,22 @@ async function updateRepoStatus(repoName, updater) {
 
 module.exports = {
   async init() {
+    try {
+      await mkdir(resolve(statusRoot), { recursive: true })
+    } catch(e) {
+      if (e.code !== 'EEXIST') {
+        throw e
+      }
+    }
+
+    try {
+      await mkdir(resolve(publicDirectory, 'peon-status'), { recursive: true })
+    } catch(e) {
+      if (e.code !== 'EEXIST') {
+        throw e
+      }
+    }
+
     await renderStatus(Date.now())
   },
 

--- a/lib/status.js
+++ b/lib/status.js
@@ -118,7 +118,11 @@ async function renderStatus(now) {
   logger.debug('rendering index', { module: 'status/render' })
   await writeFile(
     resolve(publicDirectory, 'index.html'),
-    compiled.index({ repos: status, now })
+    compiled.index({
+      repos: status,
+      now,
+      hasData: Object.keys(status).length > 0
+    })
   )
 
   logger.debug('writing render info', { module: 'status/render' })
@@ -160,6 +164,10 @@ async function updateRepoStatus(repoName, updater) {
 }
 
 module.exports = {
+  async init() {
+    await renderStatus(Date.now())
+  },
+
   // Returns buildId
   async startBuild(repoName, branch, sha) {
     return await updateRepoStatus(repoName, (repoStatus, now) => {

--- a/templates/build.hbs
+++ b/templates/build.hbs
@@ -1,4 +1,7 @@
 <title>{{buildId}} - Peon</title>
+{{#if isRunning}}
+<meta http-equiv="refresh" content="5">
+{{/if}}
 <style>
   .status-pending, .status-running, .status-cancelled {
     background-color: #ddd;

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -15,28 +15,32 @@
 </style>
 <h1>Peon status</h1>
 
-<h2>Build output</h2>
-<ul>
-  {{#each repos as |repo repoName|}}
-    {{#if repo.builtBranches}}
-      <li>
-        <b>{{repoName}}</b>
-        {{#each repo.builtBranches as |branch|}}
-          <a href="{{repoName}}/{{branch}}">{{branch}}</a>
-        {{/each}}
-      </li>
-    {{/if}}
-  {{/each}}
-</ul>
-
-<h2>Latest builds</h2>
-{{#each repos}}
-  <h3>{{@key}}</h3>
+{{#if hasData}}
+  <h2>Build output</h2>
   <ul>
-    {{#each lastBuilds}}
-      <li><a class="status-{{status}}" href="{{link}}">{{buildId}}</a> on {{branch}}, enqueued at {{date enqueued}}</li>
+    {{#each repos as |repo repoName|}}
+      {{#if repo.builtBranches}}
+        <li>
+          <b>{{repoName}}</b>
+          {{#each repo.builtBranches as |branch|}}
+            <a href="{{repoName}}/{{branch}}">{{branch}}</a>
+          {{/each}}
+        </li>
+      {{/if}}
     {{/each}}
   </ul>
-{{/each}}
+
+  <h2>Latest builds</h2>
+  {{#each repos}}
+    <h3>{{@key}}</h3>
+    <ul>
+      {{#each lastBuilds}}
+        <li><a class="status-{{status}}" href="{{link}}">{{buildId}}</a> on {{branch}}, enqueued at {{date enqueued}}</li>
+      {{/each}}
+    </ul>
+  {{/each}}
+{{else}}
+  No build jobs have run yet!
+{{/if}}
 
 <i>Last updated at {{date now}}</i>

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -1,4 +1,5 @@
 <title>Status page - Peon</title>
+<meta http-equiv="refresh" content="5">
 <style>
   .status-pending, .status-running, .status-cancelled {
     background-color: #ddd;
@@ -37,3 +38,5 @@
     {{/each}}
   </ul>
 {{/each}}
+
+<i>Last updated at {{date now}}</i>


### PR DESCRIPTION
* Remove locking in status page updates, this is useless as simultaneous builds for a project are already prevented by dispatcher
* Add auto refresh to status pages, add last update date
* Add an initial render of status pages on startup
* Fix branch not being included in root url for builds

There is still a possible conflict when two project builds update the index simultaneously, but this is really a non-issue because index rebuild uses the current state of json files anyway