### PR TITLE
feat: separate build output and status

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -8,7 +8,7 @@ const { exec } = require('child-process-promise')
 
 const { restoreCache, saveCache } = require('./cache')
 const {
-  publicDirectory,
+  outputDirectory,
   watcher: { enabled: watcherEnabled, repositories: watcherRepositories },
   webhooks: { enabled: webhooksEnabled },
   rootURLBase,
@@ -268,7 +268,7 @@ class Dispatcher {
       await status.updateBuildStep(buildId, 'deploy', 'running')
       try {
         let outputDir = resolve(tmpPath, peonConfig.output)
-        let destDir = resolve(publicDirectory, repoName, repoConfig.branch)
+        let destDir = resolve(outputDirectory, repoName, repoConfig.branch)
         logger.info(`copying output to ${destDir}`, {
           module: `dispatcher/${repoName}`
         })

--- a/lib/status.js
+++ b/lib/status.js
@@ -2,7 +2,7 @@ const { dirname, resolve } = require('path')
 const { mkdir, readdir, readFile, writeFile } = require('fs-extra')
 const Handlebars = require('handlebars')
 
-const { publicDirectory, workingDirectory } = require('./config')
+const { statusDirectory, workingDirectory } = require('./config')
 const logger = require('./logger')
 
 const statusRoot = resolve(workingDirectory, 'status')
@@ -61,12 +61,19 @@ async function renderStatus(now) {
 
       if (build.updated > lastRender) {
         logger.debug(`rendering build ${buildId}`, { module: 'status/render' })
+
+        let [repoName, buildNum] = buildId.split('#')
+
+        try {
+          await mkdir(resolve(statusDirectory, repoName), { recursive: true })
+        } catch(e) {
+          if (e.code !== 'EEXIST') {
+            throw e
+          }
+        }
+
         await writeFile(
-          resolve(
-            publicDirectory,
-            'peon-status',
-            `${buildId.replace(/#/, '-')}.html`
-          ),
+          resolve(statusDirectory, repoName, `${buildNum}.html`),
           compiled.build(
             Object.assign(build, {
               buildId,
@@ -85,7 +92,7 @@ async function renderStatus(now) {
       .map((buildId) =>
         Object.assign(builds[buildId], {
           buildId,
-          link: `peon-status/${buildId.replace(/#/, '-')}.html`
+          link: `${buildId.replace(/#/, '/')}.html`
         })
       )
 
@@ -109,7 +116,7 @@ async function renderStatus(now) {
   // Render index
   logger.debug('rendering index', { module: 'status/render' })
   await writeFile(
-    resolve(publicDirectory, 'index.html'),
+    resolve(statusDirectory, 'index.html'),
     compiled.index({
       repos: status,
       now,
@@ -166,7 +173,7 @@ module.exports = {
     }
 
     try {
-      await mkdir(resolve(publicDirectory, 'peon-status'), { recursive: true })
+      await mkdir(resolve(statusDirectory, 'peon-status'), { recursive: true })
     } catch(e) {
       if (e.code !== 'EEXIST') {
         throw e


### PR DESCRIPTION
Output project builds and peon status pages in separate directories.

Output builds in $project/$buildnum.html instead of peon-status/$project-$buildnum.html.

Closes #7 