### PR TITLE
remote deploy fixes

### DIFF
--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -144,7 +144,7 @@ class Build {
       this.debug(`opened repo from ${repoPath}`)
     } catch(e) {
       // eslint-disable-next-line new-cap
-      repo = await Git.Clone(repoURL, repoPath, { gitFetchOpts })
+      repo = await Git.Clone(repoURL, repoPath, { fetchOpts: gitFetchOpts })
       this.debug(`cloned repo into ${repoPath}`)
       cloned = true
     }
@@ -332,7 +332,7 @@ class Build {
     }
 
     let isRemote = destination.destination.indexOf(':') !== -1
-    let destDir
+    let destDir, tmpDir
 
     if (isRemote) {
       // Create a temporary directory with the relative destination path inside
@@ -341,7 +341,7 @@ class Build {
       // instead of doing rsync outputDir/ host:/destination/repo/branch/, which
       // would fail if repo/branch does not exist remotely, we first move
       // outputDir to TMPDIR/repo/branch then rsync TMPDIR/ host:/destination/
-      let tmpDir = await mkdtemp(tmpdir(), `peon-output-${repoName}-`)
+      tmpDir = await mkdtemp(resolve(tmpdir(), `peon-output-${repoName}-`))
       let movedOutput = resolve(tmpDir, pathInDestination)
       try {
         await mkdir(dirname(movedOutput), {
@@ -355,7 +355,7 @@ class Build {
       this.debug(`moving ${outputDir} to ${movedOutput}`)
       await move(outputDir, movedOutput)
       destDir = destination.destination
-      outputDir = movedOutput
+      outputDir = tmpDir
     } else {
       // Create intermediate directories
       destDir = resolve(destination.destination, pathInDestination)
@@ -393,6 +393,10 @@ class Build {
     await new Promise((resolve, reject) =>
       rsync.execute((err) => (err ? reject(err) : resolve()))
     )
+
+    if (tmpDir) {
+      await remove(tmpDir)
+    }
 
     this.info(`built ${sha} successfully`)
   }


### PR DESCRIPTION
Included:
- fixed the name of fetch options in a Git.clone call
- fixed wrong call to mkdtemp, a resolve call was missing
- fixed wrong remote deployment source path
- remove tmpDir created for remote deployment