### PR TITLE
Improve links to build outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ The configuration file contains the following keys:
     must exist.
   - `destinations.$name.rootUrl`: root URL path  the destination is served by a
     webserver (without the protocol/host/port).
+  - `destinations.$name.absoluteUrl`: full URL the destination is served by a
+    webserver (**with** protocol/host/port).  This is used so that peon can
+    generate links to the deployed build.
   - `destinations.$name.shell`: used only for remote destinations; shell command
     to use to connect to the remote.  You can use it to pass SSH options (for
     example `ssh -o StrictHostKeyChecking=no -i /path/to/id_rsa`).  Note that

--- a/config.sample.json
+++ b/config.sample.json
@@ -27,11 +27,13 @@
     "myremote": {
       "destination": "user@remote:/var/www/html/documentation",
       "rootUrl": "/documentation/",
+      "absoluteUrl": "https://my.remote/documentation/",
       "shell": "ssh -o StrictHostKeyChecking=no -i /path/to/id_rsa"
     },
     "local": {
       "destination": "/var/www/html/peon-builds",
-      "rootUrl": "/peon-builds/"
+      "rootUrl": "/peon-builds/",
+      "absoluteUrl": "https://my.host/peon-builds/"
     }
   },
 

--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -82,8 +82,17 @@ class Build {
 
       await this._runStep('deploy', () => this._deploy())
 
+      let {
+        destination: { absoluteUrl },
+        pathInDestination
+      } = this
+
+      // We cannot use path.join here because of the protocol:// prefix
+      if (!absoluteUrl.endsWith('/')) {
+        absoluteUrl = `${absoluteUrl}/`
+      }
       await status.finishBuild(buildId, 'success', {
-        outputURL: join(this.destination.absoluteUrl, this.pathInDestination)
+        outputURL: `${absoluteUrl}${pathInDestination}`
       })
     } catch(e) {
       if (e instanceof CancelBuild) {

--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -203,7 +203,7 @@ class Build {
     for (let destination of peonConfig.destinations || []) {
       if (!(destination.name in destinations)) {
         throw new Error(
-          `unknown build destination: '${peonConfig.destination}' in .peon.yml`
+          `unknown build destination: '${destination.name}' in .peon.yml`
         )
       }
 

--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -82,7 +82,9 @@ class Build {
 
       await this._runStep('deploy', () => this._deploy())
 
-      await status.finishBuild(buildId, 'success')
+      await status.finishBuild(buildId, 'success', {
+        outputURL: join(this.destination.absoluteUrl, this.pathInDestination)
+      })
     } catch(e) {
       if (e instanceof CancelBuild) {
         this.info(`cancelled build, ${e.message}`)

--- a/lib/status/render.js
+++ b/lib/status/render.js
@@ -88,7 +88,7 @@ module.exports = async function renderStatus(now) {
     repoStatus.lastBuilds = Object.keys(builds)
       .sort()
       .reverse()
-      .slice(0, 10)
+      .slice(0, 5)
       .map((buildId) =>
         Object.assign(builds[buildId], {
           buildId,
@@ -102,15 +102,23 @@ module.exports = async function renderStatus(now) {
           .filter((buildId) => builds[buildId].status === 'success')
           .map((buildId) => builds[buildId].branch)
       )
-    ].sort()
+    ].sort((a, b) => {
+      // Sort branches with master first
+      if ((a === 'master' && b !== 'master') || a < b) {
+        return -1
+      }
+      if ((b === 'master' && a !== 'master') || a > b) {
+        return 1
+      }
+      return 0
+    })
 
-    let masterIndex = builtBranches.indexOf('master')
-    if (masterIndex !== -1 && masterIndex !== 0) {
-      builtBranches.splice(masterIndex, 0)
-      builtBranches.unshift('master')
-    }
-
-    repoStatus.builtBranches = builtBranches
+    repoStatus.lastSuccessfulBuildByBranch = builtBranches.map(
+      (branch) =>
+        Object.values(builds)
+          .filter((b) => b.status === 'success' && b.branch === branch)
+          .sort((a, b) => b.end - a.end)[0]
+    )
   }
 
   // Render index

--- a/lib/status/status.js
+++ b/lib/status/status.js
@@ -105,7 +105,7 @@ module.exports = {
     })
   },
 
-  async finishBuild(buildId, buildStatus) {
+  async finishBuild(buildId, buildStatus, extra) {
     let [repoName] = buildId.split('#')
 
     await updateRepoStatus(repoName, (repoStatus, now) => {
@@ -115,6 +115,7 @@ module.exports = {
       build.end = now
       build.updated = now
       build.duration = build.end - build.start
+      build.extra = extra
     })
   }
 }

--- a/lib/watch/watcher.js
+++ b/lib/watch/watcher.js
@@ -18,11 +18,11 @@ class Watcher extends EventEmitter {
   constructor(repoName, repoUrl, branches) {
     super()
 
+    this.repoName = repoName
     this.info(
       `creating watcher for ${repoUrl} on branches ${branches.join(', ')}`
     )
 
-    this.repoName = repoName
     this.repoUrl = repoUrl
     this.branches = branches
 

--- a/templates/build.hbs
+++ b/templates/build.hbs
@@ -25,6 +25,7 @@ Building SHA {{sha}} on branch {{branch}}<br>
 Enqueued at {{date enqueued}}<br>
 {{#if start}}Started at {{date start}}<br>{{/if}}
 {{#if end}}Finished at {{date end}}<br>{{/if}}
+{{#if extra.outputURL}}<a href="{{extra.outputURL}}" target="_blank">Link to deployed build output</a><br>{{/if}}
 
 {{#each steps}}
   <h2 class="status-{{status}}">{{description}} <span class="duration">({{duration}} ms)</span></h2>

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -16,14 +16,14 @@
 <h1>Peon status</h1>
 
 {{#if hasData}}
-  <h2>Build output</h2>
+  <h2>Last successful builds by branch</h2>
   <ul>
     {{#each repos as |repo repoName|}}
-      {{#if repo.builtBranches}}
+      {{#if repo.lastSuccessfulBuildByBranch}}
         <li>
           <b>{{repoName}}</b>
-          {{#each repo.builtBranches as |branch|}}
-            <a href="{{repoName}}/{{branch}}">{{branch}}</a>
+          {{#each repo.lastSuccessfulBuildByBranch as |build|}}
+            <a href="{{build.extra.outputURL}}" target="_blank">{{build.branch}}</a>
           {{/each}}
         </li>
       {{/if}}

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -35,7 +35,12 @@
     <h3>{{@key}}</h3>
     <ul>
       {{#each lastBuilds}}
-        <li><a class="status-{{status}}" href="{{link}}">{{buildId}}</a> on {{branch}}, enqueued at {{date enqueued}}</li>
+        <li>
+          <a class="status-{{status}}" href="{{link}}">{{buildId}}</a>
+          on {{branch}},
+          enqueued at {{date enqueued}}
+          {{#if extra.outputURL}}<a href="{{extra.outputURL}}" target="_blank">Build output</a>{{/if}}
+        </li>
       {{/each}}
     </ul>
   {{/each}}


### PR DESCRIPTION
This PR adds an "absoluteURL" setting to destinations so that peon can generate links to the build output on its status pages even for remote deployments.

Closes #17 