### PR TITLE
Add tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,76 @@
+defaults: &defaults
+  docker:
+    - image: circleci/node:10
+      environment:
+        JOBS: 2
+  working_directory: ~/peon
+
+version: 2
+jobs:
+  checkout_code:
+    <<: *defaults
+    steps:
+      - checkout
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
+  install_dependencies:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - peon-node10-v1-{{ checksum "yarn.lock" }}
+      - run:
+          name: Avoid hosts unknown for github
+          command: mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
+      - run:
+          name: Yarn Install
+          command: yarn install --non-interactive
+      - save_cache:
+          key: peon-node10-v1-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/peon/node_modules
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
+  lint:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Lint
+          command: yarn lint
+
+  test:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Install rsync
+          command: sudo apt update && sudo apt install rsync
+      - run:
+          name: Run Tests
+          command: yarn test
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - checkout_code
+      - install_dependencies:
+          requires:
+            - checkout_code
+      - lint:
+          requires:
+            - install_dependencies
+      - test:
+          requires:
+            - install_dependencies

--- a/index.js
+++ b/index.js
@@ -1,1 +1,3 @@
-require('./lib/peon')()
+const Peon = require('./lib/peon')
+Peon.loadModules()
+new Peon().start()

--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -1,21 +1,10 @@
 const { tmpdir } = require('os')
 const { dirname, join, resolve } = require('path')
-
 const { exec } = require('child-process-promise')
 const { move, mkdir, mkdtemp, readFile, remove, stat } = require('fs-extra')
 const yaml = require('js-yaml')
-const Git = require('nodegit')
-const Rsync = require('rsync')
 
-const { restoreCache, saveCache } = require('./cache')
-const { destinations, workingDirectory } = require('../config')
-const status = require('../status/status')
-const logger = require('../utils/logger')('build')
-const { gitFetchOpts } = require('../utils/misc')
-const Environment = require('../utils/environment')
-const Queue = require('../utils/queue')
-
-const reposDirectory = resolve(workingDirectory, 'repos')
+const { lookup, register } = require('../injections')
 
 class CancelBuild extends Error {}
 class BuildWarning extends Error {
@@ -28,35 +17,52 @@ class BuildWarning extends Error {
 class Build {
   constructor(buildId, payload, repoConfig) {
     this.buildId = buildId
-
     this.sha = payload.head_commit.id
-
     this.repoName = repoConfig.name
     this.repoURL = repoConfig.url
     this.refMode = repoConfig.refMode
     this.ref = repoConfig.ref
+  }
 
-    this.repoPath = resolve(reposDirectory, this.repoName)
+  get logger() {
+    if (!this._logger) {
+      let { getLogger } = lookup()
+      this._logger = getLogger('build')
+    }
+    return this._logger
+  }
+
+  get reposDirectory() {
+    let {
+      config: { workingDirectory }
+    } = lookup()
+    return resolve(workingDirectory, 'repos')
+  }
+
+  get repoPath() {
+    let { reposDirectory, repoName } = this
+    return resolve(reposDirectory, repoName)
   }
 
   debug(msg) {
-    logger.debug(msg, { module: `build/${this.buildId}` })
+    this.logger.debug(msg, { module: `build/${this.buildId}` })
   }
 
   info(msg) {
-    logger.info(msg, { module: `build/${this.buildId}` })
+    this.logger.info(msg, { module: `build/${this.buildId}` })
   }
 
   warn(msg) {
-    logger.warn(msg, { module: `build/${this.buildId}` })
+    this.logger.warn(msg, { module: `build/${this.buildId}` })
   }
 
   error(msg) {
-    logger.error(msg, { module: `build/${this.buildId}` })
+    this.logger.error(msg, { module: `build/${this.buildId}` })
   }
 
   async build() {
     let { buildId, sha } = this
+    let { status } = lookup()
 
     this.start = new Date()
     this.info(`building commit ${sha}`)
@@ -66,7 +72,7 @@ class Build {
       await this._runStep('create workspace', () => this._createWorkspace())
       await this._runStep('read .peon.yml', () => this._readPeonConfig())
 
-      let { peonConfig } = this
+      let { env, peonConfig } = this
 
       if (peonConfig.cache && peonConfig.cache.length) {
         await this._runStep('restore cache', () => this._restoreCache())
@@ -94,7 +100,7 @@ class Build {
         absoluteUrl = `${absoluteUrl}/`
       }
       await status.finishBuild(buildId, 'success', {
-        outputURL: `${absoluteUrl}${pathInDestination}`
+        outputURL: `${absoluteUrl}${env.evaluate(pathInDestination)}`
       })
     } catch(e) {
       if (e instanceof CancelBuild) {
@@ -113,6 +119,7 @@ class Build {
 
   async _runStep(stepName, step) {
     let { buildId } = this
+    let { status, Queue } = lookup()
 
     function updateStep(stepStatus, output) {
       return status.updateBuildStep(buildId, stepName, stepStatus, output)
@@ -149,15 +156,18 @@ class Build {
   }
 
   async _updateRepository() {
+    let { Git, gitFetchOpts } = lookup()
     let { repoPath, repoURL } = this
-
     let repo, cloned
+
     try {
       repo = await Git.Repository.open(repoPath)
       this.debug(`opened repo from ${repoPath}`)
     } catch(e) {
       // eslint-disable-next-line new-cap
-      repo = await Git.Clone(repoURL, repoPath, { fetchOpts: gitFetchOpts })
+      repo = await Git.Clone(repoURL, repoPath, {
+        fetchOpts: gitFetchOpts
+      })
       this.debug(`cloned repo into ${repoPath}`)
       cloned = true
     }
@@ -176,6 +186,7 @@ class Build {
 
     this.debug(`cloning into ${workspace}`)
 
+    let { Git } = lookup()
     // eslint-disable-next-line new-cap
     let tmpRepo = await Git.Clone(repoPath, workspace)
     let ref = await tmpRepo.createBranch('peon-build', sha)
@@ -185,6 +196,10 @@ class Build {
   }
 
   async _readPeonConfig() {
+    let {
+      config: { destinations },
+      Environment
+    } = lookup()
     let { workspace, ref, refMode, buildId, start, repoName, sha } = this
 
     // Load config file
@@ -300,14 +315,15 @@ class Build {
   }
 
   async _restoreCache() {
-    let {
-      repoName,
-      workspace,
-      peonConfig: { cache }
-    } = this
+    let { repoName, workspace, peonConfig } = this
+    let { cache } = lookup()
 
     try {
-      let restoredPaths = await restoreCache(repoName, workspace, cache)
+      let restoredPaths = await cache.restoreCache(
+        repoName,
+        workspace,
+        peonConfig.cache
+      )
 
       return restoredPaths.length
         ? `restored paths ${restoredPaths.join(', ')}`
@@ -318,14 +334,15 @@ class Build {
   }
 
   async _saveCache() {
-    let {
-      repoName,
-      workspace,
-      peonConfig: { cache }
-    } = this
+    let { repoName, workspace, peonConfig } = this
+    let { cache } = lookup()
 
     try {
-      let savedPaths = await saveCache(repoName, workspace, cache)
+      let savedPaths = await cache.saveCache(
+        repoName,
+        workspace,
+        peonConfig.cache
+      )
       return savedPaths.length
         ? `saved paths ${savedPaths.join(', ')}`
         : 'found nothing to save'
@@ -368,8 +385,16 @@ class Build {
     let evaluatedPathInDest = env.evaluate(pathInDestination)
     let outputDir = resolve(workspace, peonConfig.output)
 
-    if (!(await stat(outputDir)).isDirectory()) {
-      throw new Error(`output directory ${peonConfig.output} not found`)
+    try {
+      if (!(await stat(outputDir)).isDirectory()) {
+        throw new Error(`output '${peonConfig.output}' is not a directory`)
+      }
+    } catch(e) {
+      if (e.code === 'ENOENT') {
+        throw new Error(`output directory '${peonConfig.output}' not found`)
+      } else {
+        throw e
+      }
     }
 
     let isRemote = destination.destination.indexOf(':') !== -1
@@ -419,6 +444,7 @@ class Build {
       destDir = `${destDir}/`
     }
 
+    let { Rsync } = lookup()
     let rsync = new Rsync()
       .set('partial')
       .set('recursive')
@@ -443,4 +469,6 @@ class Build {
   }
 }
 
-module.exports = Build
+register(CancelBuild)
+register(BuildWarning)
+register(Build)

--- a/lib/build/cache.js
+++ b/lib/build/cache.js
@@ -1,154 +1,191 @@
 const { createHash } = require('crypto')
 const { access, mkdir, readdir, readFile, stat, unlink } = require('fs-extra')
 const { resolve } = require('path')
-const Tar = require('tar')
+const { lookup, register, registerLazy } = require('../injections')
 
-const { workingDirectory, cacheValidity } = require('../config')
-const logger = require('../utils/logger')('cache')
+class Cache {
+  get logger() {
+    if (!this._logger) {
+      let { getLogger } = lookup()
+      this._logger = getLogger('build')
+    }
+    return this._logger
+  }
 
-const cacheDirectory = resolve(workingDirectory, 'cache')
+  get cacheDirectory() {
+    let {
+      config: { workingDirectory }
+    } = lookup()
+    return resolve(workingDirectory, 'cache')
+  }
 
-async function ensureCacheDirExists() {
-  try {
-    await mkdir(cacheDirectory, { recursive: true })
-  } catch(e) {
-    if (e.code !== 'EEXIST') {
-      throw e
+  async _ensureCacheDirExists() {
+    try {
+      await mkdir(this.cacheDirectory, { recursive: true })
+    } catch(e) {
+      if (e.code !== 'EEXIST') {
+        throw e
+      }
     }
   }
-}
 
-async function getCacheFilename(repoName, repoRoot, entry) {
-  if (!entry.digest) {
-    let keyFile = resolve(repoRoot, entry.source)
-    let keyHash = createHash('sha256')
+  async _getCacheFilename(repoName, repoRoot, entry) {
+    let { logger } = this
 
-    try {
-      keyHash.update(await readFile(keyFile))
-    } catch(e) {
-      logger.debug(`could not read key file ${entry.source}`, {
+    if (!entry.digest) {
+      let keyFile = resolve(repoRoot, entry.source)
+      let keyHash = createHash('sha256')
+
+      try {
+        keyHash.update(await readFile(keyFile))
+      } catch(e) {
+        logger.debug(`could not read key file ${entry.source}`, {
+          module: `cache/${repoName}`
+        })
+        return
+      }
+
+      entry.digest = keyHash.digest('hex')
+    }
+
+    let cleanPath = entry.path.replace(/\//g, '_')
+    return `${repoName}-${cleanPath}-${entry.digest}.tar`
+  }
+
+  async _pruneCache() {
+    let { cacheDirectory, logger } = this
+    let {
+      config: { cacheValidity }
+    } = lookup()
+
+    let minMtime = Date.now() - cacheValidity
+
+    for (let file of await readdir(cacheDirectory)) {
+      let filePath = resolve(cacheDirectory, file)
+      let fileStat = await stat(filePath)
+      if (fileStat.mtimeMs < minMtime) {
+        logger.debug(`removing expired ${file}`, { module: 'cache' })
+        await unlink(filePath)
+      }
+    }
+  }
+
+  async restoreCache(repoName, repoRoot, cacheEntries) {
+    let { cacheDirectory, logger } = this
+
+    await this._ensureCacheDirExists()
+    await this._pruneCache()
+
+    let restored = []
+
+    for (let entry of cacheEntries) {
+      let cacheFilename = await this._getCacheFilename(
+        repoName,
+        repoRoot,
+        entry
+      )
+      if (!cacheFilename) {
+        continue
+      }
+
+      let tarball = resolve(cacheDirectory, cacheFilename)
+      try {
+        await access(tarball)
+      } catch(e) {
+        if (e.code === 'ENOENT') {
+          logger.debug(
+            `tarball ${cacheFilename} not found, ${
+              entry.path
+            } will not be restored`,
+            {
+              module: `cache/${repoName}`
+            }
+          )
+          continue
+        }
+
+        throw e
+      }
+
+      logger.debug(`restoring ${entry.path} from ${cacheFilename}`, {
         module: `cache/${repoName}`
       })
-      return
+
+      let { Tar } = lookup()
+      await Tar.extract({
+        cwd: repoRoot,
+        file: tarball
+      })
+
+      restored.push(entry.path)
     }
 
-    entry.digest = keyHash.digest('hex')
+    return restored
   }
 
-  let cleanPath = entry.path.replace(/\//g, '_')
-  return `${repoName}-${cleanPath}-${entry.digest}.tar`
-}
+  async saveCache(repoName, repoRoot, cacheEntries) {
+    let { cacheDirectory, logger } = this
 
-async function pruneCache() {
-  let minMtime = Date.now() - cacheValidity
+    await this._ensureCacheDirExists()
 
-  for (let file of await readdir(cacheDirectory)) {
-    let filePath = resolve(cacheDirectory, file)
-    let fileStat = await stat(filePath)
-    if (fileStat.mtimeMs < minMtime) {
-      logger.debug(`removing expired ${file}`, { module: 'cache' })
-      await unlink(filePath)
-    }
-  }
-}
+    let saved = []
 
-async function restoreCache(repoName, repoRoot, cacheEntries) {
-  await ensureCacheDirExists()
-  await pruneCache()
+    for (let entry of cacheEntries) {
+      try {
+        await access(resolve(repoRoot, entry.path))
+      } catch(e) {
+        if (e.code === 'ENOENT') {
+          logger.debug(`path ${entry.path} not found, will not be saved`, {
+            module: `cache/${repoName}`
+          })
+          continue
+        }
 
-  let restored = []
+        throw e
+      }
 
-  for (let entry of cacheEntries) {
-    let cacheFilename = await getCacheFilename(repoName, repoRoot, entry)
-    if (!cacheFilename) {
-      continue
-    }
+      let cacheFilename = await this._getCacheFilename(
+        repoName,
+        repoRoot,
+        entry
+      )
+      if (!cacheFilename) {
+        continue
+      }
 
-    let tarball = resolve(cacheDirectory, cacheFilename)
-    try {
-      await access(tarball)
-    } catch(e) {
-      if (e.code === 'ENOENT') {
+      let destination = resolve(cacheDirectory, cacheFilename)
+      let fileExists = false
+      try {
+        await access(destination)
+        fileExists = true
+      } catch(e) {
+        if (e.code !== 'ENOENT') {
+          throw e
+        }
+      }
+
+      if (fileExists) {
         logger.debug(
-          `tarball ${cacheFilename} not found, ${
-            entry.path
-          } will not be restored`,
+          `skipping save of ${entry.path}, ${cacheFilename} exists`,
           {
             module: `cache/${repoName}`
           }
         )
-        continue
-      }
-
-      throw e
-    }
-
-    logger.debug(`restoring ${entry.path} from ${cacheFilename}`, {
-      module: `cache/${repoName}`
-    })
-
-    await Tar.extract({
-      cwd: repoRoot,
-      file: tarball
-    })
-
-    restored.push(entry.path)
-  }
-
-  return restored
-}
-
-async function saveCache(repoName, repoRoot, cacheEntries) {
-  await ensureCacheDirExists()
-
-  let saved = []
-
-  for (let entry of cacheEntries) {
-    try {
-      await access(resolve(repoRoot, entry.path))
-    } catch(e) {
-      if (e.code === 'ENOENT') {
-        logger.debug(`path ${entry.path} not found, will not be saved`, {
+      } else {
+        logger.debug(`saving ${entry.path} as ${cacheFilename}`, {
           module: `cache/${repoName}`
         })
-        continue
-      }
 
-      throw e
-    }
+        let { Tar } = lookup()
+        await Tar.create({ cwd: repoRoot, file: destination }, [entry.path])
 
-    let cacheFilename = await getCacheFilename(repoName, repoRoot, entry)
-    if (!cacheFilename) {
-      continue
-    }
-
-    let fileExists = false
-    try {
-      await access(cacheFilename)
-      fileExists = true
-    } catch(e) {
-      if (e.code !== 'ENOENT') {
-        throw e
+        saved.push(entry.path)
       }
     }
 
-    if (fileExists) {
-      logger.debug(`skipping save of ${entry.path}, ${cacheFilename} exists`, {
-        module: `cache/${repoName}`
-      })
-    } else {
-      logger.debug(`saving ${entry.path} as ${cacheFilename}`, {
-        module: `cache/${repoName}`
-      })
-
-      let destination = resolve(cacheDirectory, cacheFilename)
-      await Tar.create({ cwd: repoRoot, file: destination }, [entry.path])
-
-      saved.push(entry.path)
-    }
+    return saved
   }
-
-  return saved
 }
 
-module.exports = { saveCache, restoreCache }
+register(Cache)
+registerLazy('cache', () => new Cache())

--- a/lib/build/dispatcher.js
+++ b/lib/build/dispatcher.js
@@ -1,25 +1,31 @@
-const Build = require('./build')
-const {
-  watcher: { enabled: watcherEnabled, repositories: watcherRepositories },
-  webhooks: { enabled: webhooksEnabled }
-} = require('../config')
-const status = require('../status/status')
-const logger = require('../utils/logger')('dispatcher')
-const { extractRepoName } = require('../utils/misc')
-const Queue = require('../utils/queue')
+const { lookup, register, registerLazy } = require('../injections')
 
 class Dispatcher {
-  constructor() {
-    this.queue = new Queue()
+  get logger() {
+    if (!this._logger) {
+      let { getLogger } = lookup()
+      this._logger = getLogger('build')
+    }
+    return this._logger
+  }
+
+  get queue() {
+    if (!this._queue) {
+      let { Queue } = lookup()
+      this._queue = new Queue()
+    }
+    return this._queue
   }
 
   async dispatch(eventType, payload) {
-    let repoConfig = this.findRepositoryToHandle(eventType, payload)
+    let { logger } = this
+    let repoConfig = this.findRepository(eventType, payload)
 
     if (!repoConfig) {
       return
     }
 
+    let { status, Build } = lookup()
     let buildId = await status.startBuild(
       repoConfig.url,
       repoConfig.name,
@@ -29,6 +35,7 @@ class Dispatcher {
     )
 
     let build = new Build(buildId, payload, repoConfig)
+
     logger.debug(`enqueuing build ${buildId}`, {
       module: `dispatcher/${repoConfig.name}`
     })
@@ -36,7 +43,9 @@ class Dispatcher {
     this.queue.run(() => build.build())
   }
 
-  findRepositoryToHandle(eventType, payload) {
+  findRepository(eventType, payload) {
+    let { logger } = this
+
     if (eventType !== 'push') {
       logger.debug(`unhandled event ${eventType}`, { module: 'dispatcher' })
       return null
@@ -61,6 +70,13 @@ class Dispatcher {
       return null
     }
 
+    let {
+      misc: { extractRepoName },
+      config: {
+        watcher: { enabled: watcherEnabled, repositories: watcherRepositories },
+        webhooks: { enabled: webhooksEnabled }
+      }
+    } = lookup()
     let repoName = extractRepoName(url)
 
     if (watcherEnabled) {
@@ -93,4 +109,5 @@ class Dispatcher {
   }
 }
 
-module.exports = Dispatcher
+register(Dispatcher)
+registerLazy('dispatcher', () => new Dispatcher())

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,0 @@
-const { dirname, join } = require('path')
-const configPath
-  = process.env.PEON_CONFIG || join(dirname(__dirname), 'config.json')
-module.exports = require(configPath)

--- a/lib/injections.js
+++ b/lib/injections.js
@@ -1,0 +1,42 @@
+/*
+  Dependency injection utilities for peon
+
+  Call register('name', value) or register(Class) to register modules for
+  injection.
+
+  Call registerLazy('name', initializer) to register modules with a lazy
+  initializer.
+
+  Call lookup('name') or const { name, ... } = lookup() to get modules.
+ */
+
+const registry = {}
+const lazies = {}
+
+function registerLazy(key, initializer) {
+  delete lazies[key]
+
+  registry.__defineGetter__(key, function() {
+    if (!lazies[key]) {
+      lazies[key] = initializer()
+    }
+
+    return lazies[key]
+  })
+}
+
+function register(key, value) {
+  // Allow shorthand registering of ctors
+  if (typeof key === 'function') {
+    value = key
+    key = value.name
+  }
+
+  registerLazy(key, () => value)
+}
+
+function lookup(key) {
+  return key ? registry[key] : registry
+}
+
+module.exports = { register, registerLazy, lookup }

--- a/lib/peon.js
+++ b/lib/peon.js
@@ -1,41 +1,97 @@
 /* eslint-disable camelcase */
 
-const {
-  watcher: { enabled: watcherEnabled, repositories: watcherRepositories },
-  webhooks: { enabled: webhooksEnabled }
-} = require('./config')
-const Dispatcher = require('./build/dispatcher')
-const status = require('./status/status')
-const { extractRepoName } = require('./utils/misc')
-const Watcher = require('./watch/watcher')
-const webhooks = require('./watch/webhooks')
+const requireDirectory = require('require-directory')
+const { lookup, register } = require('./injections')
 
-module.exports = async function() {
-  await status.init()
+const moduleDirs = ['build', 'status', 'utils', 'watch']
 
-  let dispatcher = new Dispatcher()
+class Peon {
+  static loadModules() {
+    // Register external modules so they can be mocked
+    register('Git', require('nodegit'))
+    register('Handlebars', require('handlebars'))
+    register('Octokit', require('@octokit/rest'))
+    register('Rsync', require('rsync'))
+    register('Tar', require('tar'))
 
-  if (watcherEnabled) {
-    for (let repoConfig of watcherRepositories) {
-      let { url, branches } = repoConfig
-      let repoName = extractRepoName(url)
-
-      let watcher = new Watcher(repoName, url, branches)
-      watcher.on('change', (ref, commitSHA) => {
-        dispatcher.dispatch('push', {
-          ref,
-          head_commit: { id: commitSHA },
-          repository: {
-            ssh_url: url
-          }
-        })
-      })
+    // Load internal modules
+    for (let dir of moduleDirs) {
+      requireDirectory(module, dir)
     }
   }
 
-  if (webhooksEnabled) {
-    let webhookServer = webhooks()
-    webhookServer.on('push', (repo, data) => dispatcher.dispatch('push', data))
-    webhookServer.start()
+  get logger() {
+    if (!this._logger) {
+      let { getLogger } = lookup()
+      this._logger = getLogger('peon')
+    }
+    return this._logger
+  }
+
+  async start() {
+    let {
+      Watcher,
+      WebhookServer,
+      dispatcher,
+      config: {
+        watcher: { enabled: watcherEnabled, repositories: watcherRepositories },
+        webhooks: { enabled: webhooksEnabled }
+      },
+      misc: { extractRepoName }
+    } = lookup()
+
+    this.logger.info('Starting peon...', { module: 'peon' })
+
+    this.watchers = []
+    if (watcherEnabled) {
+      for (let repoConfig of watcherRepositories) {
+        let { url, branches } = repoConfig
+        let repoName = extractRepoName(url)
+
+        let watcher = new Watcher(repoName, url, branches)
+        watcher.on('change', (ref, commitSHA) => {
+          dispatcher.dispatch('push', {
+            ref,
+            head_commit: { id: commitSHA },
+            repository: {
+              ssh_url: url
+            }
+          })
+        })
+        watcher.start()
+
+        this.watchers.push(watcher)
+      }
+    }
+
+    if (webhooksEnabled) {
+      this.webhookServer = new WebhookServer()
+
+      this.webhookServer.on('push', (repo, data) =>
+        dispatcher.dispatch('push', data)
+      )
+
+      await this.webhookServer.start()
+    }
+
+    this.logger.info('Peon is ready', { module: 'peon' })
+  }
+
+  async stop() {
+    this.logger.info('Stopping peon...', { module: 'peon' })
+
+    while (this.watchers.length) {
+      let watcher = this.watchers.shift()
+      watcher.stop()
+    }
+
+    if (this.webhookServer) {
+      await this.webhookServer.stop()
+      this.webhookServer = null
+    }
+
+    this.logger.info('Stopped peon', { module: 'peon' })
   }
 }
+
+module.exports = Peon

--- a/lib/status/github.js
+++ b/lib/status/github.js
@@ -1,0 +1,72 @@
+const { lookup, register, registerLazy } = require('../injections')
+
+class GithubStatus {
+  get api() {
+    if (!this._api) {
+      let {
+        Octokit,
+        config: { githubAPIToken }
+      } = lookup()
+
+      this._api = githubAPIToken
+        ? new Octokit({ auth: `token ${githubAPIToken}` })
+        : null
+    }
+
+    return this._api
+  }
+
+  get logger() {
+    if (!this._logger) {
+      let { getLogger } = lookup()
+      this._logger = getLogger('status')
+    }
+    return this._logger
+  }
+
+  get queue() {
+    if (!this._queue) {
+      let { Queue } = lookup()
+      this._queue = new Queue()
+    }
+    return this._queue
+  }
+
+  update(repoUrl, buildId, sha, state, description) {
+    let { api, queue } = this
+    let {
+      misc: { extractGithubRepo },
+      config: { statusUrl }
+    } = lookup()
+    let githubRepo = extractGithubRepo(repoUrl)
+
+    if (!githubRepo || !api) {
+      return
+    }
+
+    queue.run(() =>
+      api.repos
+        .createStatus({
+          owner: githubRepo.org,
+          repo: githubRepo.repo,
+          sha,
+          state,
+          // eslint-disable-next-line camelcase
+          target_url: `${statusUrl}${
+            statusUrl.endsWith('/') ? '' : '/'
+          }${buildId.replace(/#/, '/')}.html`,
+          context: 'peon',
+          description
+        })
+        .catch((e) => {
+          this.logger.warn('could not update GitHub status', {
+            module: 'status/github'
+          })
+          this.logger.warn(e.stack)
+        })
+    )
+  }
+}
+
+register(GithubStatus)
+registerLazy('githubStatus', () => new GithubStatus())

--- a/lib/status/render.js
+++ b/lib/status/render.js
@@ -1,142 +1,247 @@
 const { dirname, resolve } = require('path')
 const { mkdir, readdir, readFile, writeFile } = require('fs-extra')
-const Handlebars = require('handlebars')
 
-const { statusDirectory, workingDirectory } = require('../config')
-const logger = require('../utils/logger')('status')
-
-const statusJSONDirectory = resolve(workingDirectory, 'status')
-
-Handlebars.registerHelper('date', function(timestamp) {
-  return new Date(timestamp).toISOString()
-})
+const { lookup, register, registerLazy } = require('../injections')
 
 const templateDir = resolve(dirname(dirname(__dirname)), 'templates')
 const templates = ['index', 'build']
-const compiled = {}
 
-module.exports = async function renderStatus(now) {
-  // Compile templates if not already done
-  for (let t of templates) {
-    if (!compiled[t]) {
-      logger.debug(`compiling template ${t}`, { module: 'status/render' })
-      compiled[t] = Handlebars.compile(
-        (await readFile(resolve(templateDir, `${t}.hbs`))).toString()
+function sortBuilds(a, b) {
+  let [, idA] = a.split('#')
+  let [, idB] = b.split('#')
+
+  return Number(idA) - Number(idB)
+}
+
+class Renderer {
+  get logger() {
+    if (!this._logger) {
+      let { getLogger } = lookup()
+      this._logger = getLogger('status')
+    }
+    return this._logger
+  }
+
+  get statusRoot() {
+    let {
+      config: { workingDirectory }
+    } = lookup()
+    return resolve(workingDirectory, 'status')
+  }
+
+  get renderInfoFile() {
+    let { statusRoot } = this
+    return resolve(statusRoot, 'peon-status.json')
+  }
+
+  async init() {
+    let { Handlebars } = lookup()
+
+    if (!this._initDone) {
+      Handlebars.registerHelper('date', function(timestamp) {
+        return new Date(timestamp).toISOString()
+      })
+
+      let { logger } = this
+
+      for (let t of templates) {
+        let key = `${t}Template`
+
+        if (!this[key]) {
+          logger.debug(`compiling template ${t}`, { module: 'status/render' })
+          this[key] = Handlebars.compile(
+            (await readFile(resolve(templateDir, `${t}.hbs`))).toString()
+          )
+        }
+      }
+    }
+
+    this._initDone = true
+  }
+
+  async _ensureDirsExist() {
+    let { statusRoot } = this
+
+    try {
+      await mkdir(statusRoot, { recursive: true })
+    } catch(e) {
+      if (e.code !== 'EEXIST') {
+        throw e
+      }
+    }
+  }
+
+  async _getLastRender() {
+    let { renderInfoFile, lastRender } = this
+
+    if (typeof lastRender === 'undefined') {
+      await this._ensureDirsExist()
+
+      try {
+        this.lastRender = JSON.parse(await readFile(renderInfoFile)).lastRender
+      } catch(e) {
+        this.lastRender = 0
+      }
+    }
+
+    return this.lastRender
+  }
+
+  async _setLastRender(now) {
+    let { renderInfoFile } = this
+
+    this.lastRender = now
+
+    await this._ensureDirsExist()
+    await writeFile(renderInfoFile, JSON.stringify({ lastRender: now }))
+  }
+
+  async _readReposStatus() {
+    let { statusRoot } = this
+    let status = {}
+
+    await this._ensureDirsExist()
+    for (let file of await readdir(statusRoot)) {
+      if (file === 'peon-status.json') {
+        continue
+      }
+
+      status[file.replace(/\.json$/, '')] = JSON.parse(
+        await readFile(resolve(statusRoot, file))
       )
     }
+
+    return status
   }
 
-  // Load last render info
-  logger.debug('loading render info', { module: 'status/render' })
-  let renderInfoFile = resolve(statusJSONDirectory, 'peon-status.json')
-  let renderInfo
-  try {
-    renderInfo = JSON.parse(await readFile(renderInfoFile))
-  } catch(e) {
-    renderInfo = { lastRender: 0 }
-  }
+  async _renderBuild(buildId, buildData) {
+    let { logger, buildTemplate } = this
 
-  let { lastRender } = renderInfo
+    let {
+      config: { statusDirectory }
+    } = lookup()
 
-  // Load status for all repos
-  let status = {}
-  for (let file of await readdir(statusJSONDirectory)) {
-    if (file === 'peon-status.json') {
-      continue
-    }
+    let lastRender = await this._getLastRender()
 
-    logger.debug(`reading status file ${file}`, { module: 'status/render' })
-    status[file.replace(/\.json$/, '')] = JSON.parse(
-      await readFile(resolve(statusJSONDirectory, file))
-    )
-  }
+    if (buildData.updated > lastRender) {
+      logger.debug(`rendering build ${buildId}`, {
+        module: 'status/render'
+      })
 
-  for (let repo in status) {
-    let repoStatus = status[repo]
-    let { builds } = repoStatus
+      let [repoName, buildNum] = buildId.split('#')
 
-    // Render builds that were updated since last render
-    for (let buildId in builds) {
-      let build = builds[buildId]
-
-      if (build.updated > lastRender) {
-        logger.debug(`rendering build ${buildId}`, { module: 'status/render' })
-
-        let [repoName, buildNum] = buildId.split('#')
-
-        try {
-          await mkdir(resolve(statusDirectory, repoName), { recursive: true })
-        } catch(e) {
-          if (e.code !== 'EEXIST') {
-            throw e
-          }
+      try {
+        await mkdir(resolve(statusDirectory, repoName), { recursive: true })
+      } catch(e) {
+        if (e.code !== 'EEXIST') {
+          throw e
         }
+      }
 
-        await writeFile(
-          resolve(statusDirectory, repoName, `${buildNum}.html`),
-          compiled.build(
-            Object.assign(build, {
+      await writeFile(
+        resolve(statusDirectory, repoName, `${buildNum}.html`),
+        buildTemplate(
+          Object.assign(
+            {
               buildId,
-              isRunning: ['pending', 'running'].indexOf(build.status) !== -1
-            })
+              isRunning: ['pending', 'running'].indexOf(buildData.status) !== -1
+            },
+            buildData
           )
         )
+      )
+    }
+  }
+
+  async _renderRepo(repoStatus) {
+    let { builds } = repoStatus
+    for (let buildId in builds) {
+      await this._renderBuild(buildId, builds[buildId])
+    }
+  }
+
+  async _renderIndex(now, reposStatus) {
+    let { logger, indexTemplate } = this
+
+    let {
+      config: { statusDirectory }
+    } = lookup()
+
+    for (let repo in reposStatus) {
+      let repoStatus = reposStatus[repo]
+      let { builds } = repoStatus
+
+      // Extract last 5 builds
+      repoStatus.lastBuilds = Object.keys(builds)
+        .sort(sortBuilds)
+        .reverse()
+        .slice(0, 5)
+        .map((buildId) =>
+          Object.assign(builds[buildId], {
+            buildId,
+            link: `${buildId.replace(/#/, '/')}.html`
+          })
+        )
+
+      // Get all successful build IDs in reverse order
+      let successfulBuildIds = Object.keys(builds)
+        .filter((buildId) => builds[buildId].status === 'success')
+        .sort(sortBuilds)
+        .reverse()
+
+      // Get a sorted set of successfully built refs
+      let builtRefs = [
+        ...new Set(
+          successfulBuildIds.map(
+            (buildId) => builds[buildId].branch || builds[buildId].tag
+          )
+        )
+      ].sort()
+
+      // Push master to the beginning if present
+      let masterIndex = builtRefs.indexOf('master')
+      if (masterIndex) {
+        builtRefs.splice(masterIndex, 1)
+        builtRefs.unshift('master')
       }
+
+      // Map successfully built refs to their last successful build
+      repoStatus.lastSuccessfulBuildByRef = builtRefs.map(
+        (ref) =>
+          successfulBuildIds
+            .filter((id) => builds[id].branch === ref || builds[id].tag === ref)
+            .map((id) => builds[id])[0]
+      )
     }
 
-    // Crunch data for index
-    repoStatus.lastBuilds = Object.keys(builds)
-      .sort()
-      .reverse()
-      .slice(0, 5)
-      .map((buildId) =>
-        Object.assign(builds[buildId], {
-          buildId,
-          link: `${buildId.replace(/#/, '/')}.html`
-        })
-      )
-
-    let builtRefs = [
-      ...new Set(
-        Object.keys(builds)
-          .filter((buildId) => builds[buildId].status === 'success')
-          .map((buildId) => builds[buildId].branch || builds[buildId].tag)
-      )
-    ].sort((a, b) => {
-      // Sort branches with master first
-      if ((a === 'master' && b !== 'master') || a < b) {
-        return -1
-      }
-      if ((b === 'master' && a !== 'master') || a > b) {
-        return 1
-      }
-      return 0
-    })
-
-    repoStatus.lastSuccessfulBuildByRef = builtRefs.map(
-      (ref) =>
-        Object.values(builds)
-          .filter(
-            (b) => b.status === 'success' && (b.branch === ref || b.tag === ref)
-          )
-          .sort((a, b) => b.end - a.end)[0]
+    // Render index
+    logger.debug('rendering index', { module: 'status/render' })
+    await writeFile(
+      resolve(statusDirectory, 'index.html'),
+      indexTemplate({
+        repos: reposStatus,
+        now,
+        hasData: Object.keys(reposStatus).length > 0
+      })
     )
   }
 
-  // Render index
-  logger.debug('rendering index', { module: 'status/render' })
-  await writeFile(
-    resolve(statusDirectory, 'index.html'),
-    compiled.index({
-      repos: status,
-      now,
-      hasData: Object.keys(status).length > 0
-    })
-  )
+  async render(now) {
+    let { logger } = this
 
-  logger.debug('writing render info', { module: 'status/render' })
-  renderInfo.lastRender = now
-  await writeFile(renderInfoFile, JSON.stringify(renderInfo))
+    await this.init()
+    let status = await this._readReposStatus()
 
-  logger.debug('finished updating status pages', { module: 'status/render' })
+    for (let repoName in status) {
+      await this._renderRepo(status[repoName])
+    }
+
+    await this._renderIndex(now, status)
+    await this._setLastRender(now)
+
+    logger.debug('finished rendering status pages', { module: 'status/render' })
+  }
 }
+
+register(Renderer)
+registerLazy('renderer', () => new Renderer())

--- a/lib/status/status.js
+++ b/lib/status/status.js
@@ -1,86 +1,19 @@
 const { resolve } = require('path')
 const { mkdir, readFile, writeFile } = require('fs-extra')
-const Octokit = require('@octokit/rest')
 
-const renderStatus = require('./render')
-const {
-  statusDirectory,
-  statusUrl,
-  workingDirectory,
-  githubAPIToken
-} = require('../config')
-const { extractGithubRepo } = require('../utils/misc')
-const logger = require('../utils/logger')('status')
-const Queue = require('../utils/queue')
+const { lookup, register, registerLazy } = require('../injections')
 
-const statusRoot = resolve(workingDirectory, 'status')
-const GH = githubAPIToken
-  ? new Octokit({ auth: `token ${githubAPIToken}` })
-  : null
-const ghQueue = new Queue()
-
-function updateGithubStatus(repoUrl, buildId, sha, state, description) {
-  let githubRepo = extractGithubRepo(repoUrl)
-  if (!githubRepo || !GH) {
-    return
+class Status {
+  get statusRoot() {
+    let {
+      config: { workingDirectory }
+    } = lookup()
+    return resolve(workingDirectory, 'status')
   }
 
-  ghQueue.run(() =>
-    GH.repos
-      .createStatus({
-        owner: githubRepo.org,
-        repo: githubRepo.repo,
-        sha,
-        state,
-        // eslint-disable-next-line camelcase
-        target_url: `${statusUrl}${
-          statusUrl.endsWith('/') ? '' : '/'
-        }${buildId.replace(/#/, '/')}.html`,
-        context: 'peon',
-        description
-      })
-      .catch((e) => {
-        logger.warn('could not update GitHub status', {
-          module: 'status/github'
-        })
-        logger.warn(e.stack)
-      })
-  )
-}
+  async _ensureDirsExist() {
+    let { statusRoot } = this
 
-async function updateRepoStatus(repoName, updater) {
-  let ret, repoStatus
-  let now = Date.now()
-
-  let statusFile = resolve(statusRoot, `${repoName}.json`)
-
-  try {
-    await mkdir(statusRoot, { recursive: true })
-  } catch(e) {
-    if (e.code !== 'EEXIST') {
-      throw e
-    }
-  }
-
-  try {
-    repoStatus = JSON.parse(await readFile(statusFile))
-  } catch(e) {
-    repoStatus = {
-      nextBuildNum: 1,
-      builds: {}
-    }
-  }
-
-  ret = updater(repoStatus, now)
-
-  await writeFile(statusFile, JSON.stringify(repoStatus))
-  await renderStatus(now)
-
-  return ret
-}
-
-module.exports = {
-  async init() {
     try {
       await mkdir(statusRoot, { recursive: true })
     } catch(e) {
@@ -88,26 +21,45 @@ module.exports = {
         throw e
       }
     }
+  }
+
+  async _updateRepoStatus(repoName, updater) {
+    let { statusRoot } = this
+    let ret, repoStatus
+    let now = Date.now()
+
+    await this._ensureDirsExist()
+
+    let statusFile = resolve(statusRoot, `${repoName}.json`)
 
     try {
-      await mkdir(statusDirectory, { recursive: true })
+      repoStatus = JSON.parse(await readFile(statusFile))
     } catch(e) {
-      if (e.code !== 'EEXIST') {
-        throw e
+      repoStatus = {
+        nextBuildNum: 1,
+        builds: {}
       }
     }
 
-    await renderStatus(Date.now())
-  },
+    ret = updater(repoStatus, now)
+
+    await writeFile(statusFile, JSON.stringify(repoStatus))
+
+    let { renderer } = lookup()
+    await renderer.render(Date.now())
+
+    return ret
+  }
 
   // Returns buildId
   async startBuild(repoUrl, repoName, refMode, ref, sha) {
-    let buildId = await updateRepoStatus(repoName, (repoStatus, now) => {
+    return await this._updateRepoStatus(repoName, (repoStatus, now) => {
       let buildNum = repoStatus.nextBuildNum
       repoStatus.nextBuildNum++
       let buildId = `${repoName}#${buildNum}`
 
-      updateGithubStatus(
+      let { githubStatus } = lookup()
+      githubStatus.update(
         repoUrl,
         buildId,
         sha,
@@ -128,17 +80,16 @@ module.exports = {
 
       return buildId
     })
-
-    return buildId
-  },
+  }
 
   async updateBuildStep(buildId, description, status, output) {
     let [repoName] = buildId.split('#')
 
-    await updateRepoStatus(repoName, (repoStatus, now) => {
+    await this._updateRepoStatus(repoName, (repoStatus, now) => {
       let build = repoStatus.builds[buildId]
 
-      updateGithubStatus(
+      let { githubStatus } = lookup()
+      githubStatus.update(
         build.url,
         buildId,
         build.sha,
@@ -166,15 +117,16 @@ module.exports = {
         step.duration = step.end - step.start
       }
     })
-  },
+  }
 
   async finishBuild(buildId, buildStatus, extra) {
     let [repoName] = buildId.split('#')
 
-    await updateRepoStatus(repoName, (repoStatus, now) => {
+    await this._updateRepoStatus(repoName, (repoStatus, now) => {
       let build = repoStatus.builds[buildId]
 
-      updateGithubStatus(
+      let { githubStatus } = lookup()
+      githubStatus.update(
         build.url,
         buildId,
         build.sha,
@@ -194,3 +146,6 @@ module.exports = {
     })
   }
 }
+
+register(Status)
+registerLazy('status', () => new Status())

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -1,0 +1,7 @@
+const { dirname, join } = require('path')
+const { register } = require('../injections')
+
+const configPath
+  = process.env.PEON_CONFIG || join(dirname(dirname(__dirname)), 'config.json')
+
+register('config', require(configPath))

--- a/lib/utils/environment.js
+++ b/lib/utils/environment.js
@@ -1,3 +1,5 @@
+const { register } = require('../injections')
+
 class Environment {
   constructor(env = {}) {
     this.env = env
@@ -21,4 +23,4 @@ class Environment {
   }
 }
 
-module.exports = Environment
+register(Environment)

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -1,10 +1,13 @@
 const { format, transports, loggers } = require('winston')
-
-const { logger: loggerConfig } = require('../config')
+const { register, lookup } = require('../injections')
 
 const knownLoggers = []
 
-module.exports = function getLogger(category) {
+register('getLogger', function getLogger(category) {
+  let {
+    config: { logger: loggerConfig }
+  } = lookup()
+
   let level = loggerConfig
     ? loggerConfig[category] || loggerConfig.level || 'info'
     : 'info'
@@ -31,4 +34,4 @@ module.exports = function getLogger(category) {
   }
 
   return loggers.get(category)
-}
+})

--- a/lib/utils/misc.js
+++ b/lib/utils/misc.js
@@ -1,30 +1,28 @@
-const Git = require('nodegit')
+const { lookup, register } = require('../injections')
 
-const {
-  git: { authMethod, privateKey, publicKey, keyPassword }
-} = require('../config')
-
-module.exports = {
-  gitFetchOpts: {
-    callbacks: {
-      certificateCheck() {
-        return 1
-      },
-      credentials(url, userName) {
-        if (authMethod === 'key') {
-          return Git.Cred.sshKeyNew(
-            userName,
-            publicKey,
-            privateKey,
-            keyPassword
-          )
-        } else if (authMethod === 'agent') {
-          return Git.Cred.sshKeyFromAgent(userName)
+register('gitFetchOpts', {
+  callbacks: {
+    certificateCheck() {
+      return 1
+    },
+    credentials(url, userName) {
+      let {
+        Git,
+        config: {
+          git: { authMethod, privateKey, publicKey, keyPassword }
         }
+      } = lookup()
+
+      if (authMethod === 'key') {
+        return Git.Cred.sshKeyNew(userName, publicKey, privateKey, keyPassword)
+      } else if (authMethod === 'agent') {
+        return Git.Cred.sshKeyFromAgent(userName)
       }
     }
-  },
+  }
+})
 
+register('misc', {
   extractRepoName(url) {
     let pathItems = url.replace(/\/$/, '').split('/')
     return pathItems.pop().replace(/\.git$/, '')
@@ -41,4 +39,4 @@ module.exports = {
       return { org, repo }
     }
   }
-}
+})

--- a/lib/utils/queue.js
+++ b/lib/utils/queue.js
@@ -1,3 +1,5 @@
+const { register } = require('../injections')
+
 class Queue {
   constructor() {
     this.promise = Promise.resolve()
@@ -12,4 +14,4 @@ class Queue {
   }
 }
 
-module.exports = Queue
+register(Queue)

--- a/lib/watch/watcher.js
+++ b/lib/watch/watcher.js
@@ -1,94 +1,148 @@
 /* eslint-env node */
 
-const Git = require('nodegit')
 const EventEmitter = require('events')
 const { mkdir } = require('fs-extra')
 const { resolve } = require('path')
 
-const {
-  workingDirectory,
-  watcher: { interval }
-} = require('../config')
-const logger = require('../utils/logger')('watcher')
-const { gitFetchOpts } = require('../utils/misc')
-
-const reposDirectory = resolve(workingDirectory, 'repos')
+const { lookup, register } = require('../injections')
 
 class Watcher extends EventEmitter {
   constructor(repoName, repoUrl, branches) {
     super()
 
     this.repoName = repoName
-    this.info(
-      `creating watcher for ${repoUrl} on branches ${branches.join(', ')}`
-    )
-
     this.repoUrl = repoUrl
     this.branches = branches
+  }
 
-    this.checkUpdates()
+  get logger() {
+    if (!this._logger) {
+      let { getLogger } = lookup()
+      this._logger = getLogger('watcher')
+    }
+    return this._logger
+  }
+
+  get reposDirectory() {
+    let {
+      config: { workingDirectory }
+    } = lookup()
+    return resolve(workingDirectory, 'repos')
   }
 
   debug(msg) {
-    logger.debug(msg, { module: `watcher/${this.repoName}` })
+    this.logger.debug(msg, { module: `watcher/${this.repoName}` })
   }
 
   info(msg) {
-    logger.info(msg, { module: `watcher/${this.repoName}` })
+    this.logger.info(msg, { module: `watcher/${this.repoName}` })
   }
 
-  async checkUpdates() {
+  start() {
+    let { repoUrl, branches } = this
+    this.info(
+      `starting watcher for ${repoUrl} on branches ${branches.join(', ')}`
+    )
+
+    this._running = true
+    this._schedule()
+  }
+
+  stop() {
+    this._running = false
+    clearTimeout(this._timeout)
+  }
+
+  _schedule() {
+    let {
+      config: {
+        watcher: { interval }
+      }
+    } = lookup()
+    this._timeout = setTimeout(() => this._run(), interval)
+  }
+
+  async _run() {
     try {
-      let repo
-      let { repoUrl, branches } = this
-      let cloned = false
-      let repoPath = resolve(reposDirectory, this.repoName)
-
-      try {
-        await mkdir(reposDirectory, { recursive: true })
-      } catch(e) {
-        if (e.code !== 'EEXIST') {
-          throw e
-        }
-      }
-
-      try {
-        repo = await Git.Repository.open(repoPath)
-        this.debug(`opened repo from ${repoPath}`)
-      } catch(e) {
-        // eslint-disable-next-line new-cap
-        repo = await Git.Clone(repoUrl, repoPath, { fetchOpts: gitFetchOpts })
-        this.debug(`cloned repo into ${repoPath}`)
-        cloned = true
-      }
-
-      let currentSHAs = {}
-      if (!cloned) {
-        for (let branch of branches) {
-          currentSHAs[branch] = (await repo.getBranchCommit(
-            `origin/${branch}`
-          )).sha()
-          this.debug(
-            `current SHA for branch ${branch} is ${currentSHAs[branch]}`
-          )
-        }
-
-        await repo.fetch('origin', gitFetchOpts)
-      }
-
-      for (let branch of branches) {
-        let newSHA = (await repo.getBranchCommit(`origin/${branch}`)).sha()
-        this.debug(`updated SHA for branch ${branch} is ${newSHA}`)
-
-        if (newSHA !== currentSHAs[branch]) {
-          this.info(`branch ${branch} changed, new SHA is ${newSHA}`)
-          this.emit('change', `refs/heads/${branch}`, newSHA)
-        }
-      }
+      await this._check()
     } finally {
-      setTimeout(() => this.checkUpdates(), interval)
+      if (this._running) {
+        this._schedule()
+      }
+    }
+  }
+
+  async _check() {
+    let { repo, cloned } = await this._openRepository()
+    let currentSHAs = await this._getCurrentSHAs(repo, cloned)
+    await this._checkUpdates(repo, cloned, currentSHAs)
+  }
+
+  async _openRepository() {
+    let repo
+    let { repoUrl, reposDirectory } = this
+    let cloned = false
+    let repoPath = resolve(reposDirectory, this.repoName)
+
+    try {
+      await mkdir(reposDirectory, { recursive: true })
+    } catch(e) {
+      if (e.code !== 'EEXIST') {
+        throw e
+      }
+    }
+
+    let { Git, gitFetchOpts } = lookup()
+
+    try {
+      repo = await Git.Repository.open(repoPath)
+      this.debug(`opened repo from ${repoPath}`)
+    } catch(e) {
+      // eslint-disable-next-line new-cap
+      repo = await Git.Clone(repoUrl, repoPath, {
+        fetchOpts: gitFetchOpts
+      })
+      this.debug(`cloned repo into ${repoPath}`)
+      cloned = true
+    }
+
+    return { repo, cloned }
+  }
+
+  async _getCurrentSHAs(repo, cloned) {
+    let { branches } = this
+
+    let currentSHAs = {}
+    if (!cloned) {
+      for (let branch of branches) {
+        currentSHAs[branch] = (await repo.getBranchCommit(
+          `origin/${branch}`
+        )).sha()
+        this.debug(`current SHA for branch ${branch} is ${currentSHAs[branch]}`)
+      }
+    }
+
+    return currentSHAs
+  }
+
+  async _checkUpdates(repo, cloned, currentSHAs) {
+    let { branches } = this
+    let { gitFetchOpts } = lookup()
+
+    if (!cloned) {
+      await repo.fetch('origin', gitFetchOpts)
+    }
+
+    for (let branch of branches) {
+      let newSHA = (await repo.getBranchCommit(`origin/${branch}`)).sha()
+      this.debug(`updated SHA for branch ${branch} is ${newSHA}`)
+
+      if (newSHA !== currentSHAs[branch]) {
+        this.info(`branch ${branch} changed, new SHA is ${newSHA}`)
+        this.emit('change', `refs/heads/${branch}`, newSHA)
+      }
     }
   }
 }
 
-module.exports = Watcher
+register(Watcher)

--- a/lib/watch/webhooks.js
+++ b/lib/watch/webhooks.js
@@ -2,31 +2,103 @@ const express = require('express')
 const { json } = require('body-parser')
 const GithubWebHook = require('express-github-webhook')
 
-const {
-  webhooks: { port, secret }
-} = require('../config')
-const logger = require('../utils/logger')('webhooks')
+const { lookup, register } = require('../injections')
 
-module.exports = function() {
-  // eslint-disable-next-line new-cap
-  let webhookHandler = GithubWebHook({ path: '/webhooks', secret })
-
-  let app = express()
-  app.use(json())
-  app.use(webhookHandler)
-
-  return {
-    start() {
-      app.listen(port, 'localhost', () =>
-        logger.info(`listening on localhost:${port}`, { module: 'webhooks' })
-      )
-    },
-
-    on(event, callback) {
-      webhookHandler.on(event, function(repo) {
-        logger.debug(`received ${event} on ${repo}`, { module: 'webhooks' })
-        callback(...arguments)
-      })
+class WebhookServer {
+  get logger() {
+    if (!this._logger) {
+      let { getLogger } = lookup()
+      this._logger = getLogger('webhooks')
     }
+    return this._logger
+  }
+
+  get webhookHandler() {
+    if (!this._webhookHandler) {
+      let {
+        config: {
+          webhooks: { secret }
+        }
+      } = lookup()
+
+      // eslint-disable-next-line new-cap
+      this._webhookHandler = GithubWebHook({ path: '/webhooks', secret })
+    }
+    return this._webhookHandler
+  }
+
+  get app() {
+    if (!this._app) {
+      let { logger, webhookHandler } = this
+      let app = express()
+      app.use(json())
+      app.use(webhookHandler)
+
+      // eslint-disable-next-line no-unused-vars
+      app.use((err, req, res, next) => {
+        logger.error('unhandled error', { module: 'webhooks' })
+        logger.error(err, { module: 'webhooks' })
+      })
+
+      this._app = app
+    }
+    return this._app
+  }
+
+  start() {
+    return new Promise((resolve, reject) => {
+      let { app, logger } = this
+      let {
+        config: {
+          webhooks: { port }
+        }
+      } = lookup()
+
+      this.server = app.listen(port, 'localhost', (e) => {
+        if (e) {
+          logger.error('could not start listening', { module: 'webhooks' })
+          logger.error(e, { module: 'webhooks' })
+          reject(e)
+        } else {
+          logger.info(`listening on localhost:${port}`, {
+            module: 'webhooks'
+          })
+          resolve()
+        }
+      })
+    })
+  }
+
+  stop() {
+    return new Promise((resolve, reject) => {
+      let { logger, server } = this
+      if (server) {
+        server.close((e) => {
+          if (e) {
+            logger.error('could not stop listening', { module: 'webhooks' })
+            logger.error(e, { module: 'webhooks' })
+            reject(e)
+          } else {
+            logger.info('stopped listening', { module: 'webhooks' })
+            resolve()
+          }
+        })
+
+        this.server = null
+      } else {
+        resolve()
+      }
+    })
+  }
+
+  on(event, callback) {
+    let { logger, webhookHandler } = this
+
+    webhookHandler.on(event, function(repo) {
+      logger.debug(`received ${event} on ${repo}`, { module: 'webhooks' })
+      callback(...arguments)
+    })
   }
 }
+
+register(WebhookServer)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "peon",
   "version": "0.1.0",
   "scripts": {
-    "start": "node ./index.js"
+    "test": "PEON_CONFIG=$(pwd)/test/config.json mocha --file 'test/init.js' --recursive 'test/**/*.test.js'",
+    "lint": "eslint index.js lib scripts test"
   },
   "main": "index.js",
   "repository": "git@github.com:peopledoc/peon.git",
@@ -15,7 +16,6 @@
     "@octokit/rest": "^16.17.0",
     "body-parser": "^1.18.3",
     "child-process-promise": "^2.2.1",
-    "eslint-config-peopledoc": "^1.5.0",
     "express": "^4.16.4",
     "express-github-webhook": "^1.0.6",
     "fs-extra": "^7.0.1",
@@ -28,6 +28,10 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "request": "^2.88.0"
+    "chai": "^4.2.0",
+    "eslint-config-peopledoc": "^1.5.0",
+    "mocha": "^6.0.2",
+    "request": "^2.88.0",
+    "request-promise-native": "^1.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "handlebars": "^4.0.12",
     "js-yaml": "^3.12.1",
     "nodegit": "^0.24.0",
+    "require-directory": "^2.1.1",
     "rsync": "^0.6.1",
     "tar": "^4.4.8",
     "winston": "^3.1.0"

--- a/scripts/test_command
+++ b/scripts/test_command
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "output line 1"
+sleep .05 >/dev/null
+echo "output line 2"
+echo "error line" >&2
+sleep .05 >/dev/null
+echo "output line 3"
+
+
+if [ "$1" = "fail" ]; then
+  exit 1
+fi

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  env: {
+    node: true,
+    mocha: true
+  }
+}

--- a/test/config.json
+++ b/test/config.json
@@ -1,0 +1,5 @@
+{
+  "logger": {
+    "level": "emerg"
+  }
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,67 @@
+const { mkdtemp, remove } = require('fs-extra')
+const { dirname, resolve } = require('path')
+const { tmpdir } = require('os')
+
+const root = dirname(__dirname)
+const src = resolve(root, 'lib')
+const { lookup, register } = require(`${src}/injections`)
+
+const pendingCleanup = []
+
+module.exports = {
+  // Paths to peon sources
+  root,
+  src,
+
+  // Mock configuration values (requires a cleanup call)
+  mockConfig(key, value) {
+    let config = lookup('config')
+
+    let hasKey = key in config
+    let oldValue = config[key]
+
+    config[key] = value
+
+    pendingCleanup.push(() => {
+      if (!hasKey) {
+        delete config[key]
+      } else {
+        config[key] = oldValue
+      }
+    })
+  },
+
+  // Mock injectable modules (requires a cleanup call)
+  mock(name, value) {
+    let oldValue = lookup(name)
+    register(name, value)
+
+    pendingCleanup.push(() => {
+      register(name, oldValue)
+    })
+  },
+
+  // Lookup injectable modules
+  lookup,
+
+  // Create temp directories (requires a cleanup call)
+  async tempDir() {
+    let dir = await mkdtemp(resolve(tmpdir(), 'peon-test-'))
+    pendingCleanup.push(async() => {
+      await remove(dir)
+    })
+    return dir
+  },
+
+  // Restore initial state, calls cleanup function in reverse order
+  async cleanup() {
+    while (pendingCleanup.length) {
+      await pendingCleanup.pop()()
+    }
+  },
+
+  // Return a promise that resolves in ms milliseconds
+  wait(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+  }
+}

--- a/test/init.js
+++ b/test/init.js
@@ -1,0 +1,6 @@
+const { src, cleanup } = require('./helpers')
+const Peon = require(`${src}/peon`)
+
+Peon.loadModules()
+
+afterEach(cleanup)

--- a/test/system/peon.test.js
+++ b/test/system/peon.test.js
@@ -1,0 +1,128 @@
+const { resolve } = require('path')
+const { mkdir, readFile, writeFile } = require('fs-extra')
+const Git = require('nodegit')
+
+const { mockConfig, src, tempDir, wait } = require('../helpers')
+
+const Peon = require(`${src}/peon`)
+
+describe('system | peon', function() {
+  it('builds from watcher', async function() {
+    this.timeout(10000)
+    this.slow(4000)
+
+    // Mock configuration
+
+    let repoPath = resolve(await tempDir(), 'repo')
+    let workingDirectory = await tempDir()
+    let statusDirectory = await tempDir()
+    let destDirectory = await tempDir()
+
+    mockConfig('watcher', {
+      enabled: true,
+      interval: 50,
+      repositories: [{ url: repoPath, branches: ['master'] }]
+    })
+    mockConfig('webhooks', {
+      enabled: false
+    })
+    mockConfig('workingDirectory', workingDirectory)
+    mockConfig('statusDirectory', statusDirectory)
+    mockConfig('destinations', {
+      local: {
+        destination: destDirectory,
+        rootUrl: '/root/url/',
+        absoluteUrl: 'https://example.com/root/url/'
+      }
+    })
+
+    // Create repository content
+
+    await mkdir(repoPath)
+    await writeFile(
+      resolve(repoPath, 'build.sh'),
+      [
+        '#!/bin/bash',
+        'mkdir -p output',
+        'echo -n "built once" > output/file'
+      ].join('\n'),
+      { mode: 0o755 }
+    )
+    await writeFile(
+      resolve(repoPath, '.peon.yml'),
+      [
+        'output: output',
+        'commands:',
+        ' - ./build.sh',
+        'destinations:',
+        ' - name: local'
+      ].join('\n')
+    )
+
+    // Create repository and make an initial commit
+
+    let repo = await Git.Repository.init(repoPath, 0)
+    await repo.createCommitOnHead(
+      ['.peon.yml', 'build.sh'],
+      Git.Signature.create('author', 'me@example.com', Date.now(), 0),
+      Git.Signature.create('committer', 'me@example.com', Date.now(), 0),
+      'first commit'
+    )
+
+    // Start Peon
+
+    let peon = new Peon()
+    await peon.start()
+
+    // Check for deployment
+
+    let file
+    while (file !== 'built once') {
+      try {
+        file = (await readFile(
+          resolve(destDirectory, 'repo', 'master', 'file')
+        )).toString()
+      } catch(e) {
+        await wait(1000)
+      }
+    }
+
+    // Make a new commit
+
+    await writeFile(
+      resolve(repoPath, 'build.sh'),
+      [
+        '#!/bin/bash',
+        'mkdir -p output',
+        'echo -n "built again" > output/file'
+      ].join('\n'),
+      { mode: 0o755 }
+    )
+    await repo.createCommitOnHead(
+      ['build.sh'],
+      Git.Signature.create('author', 'me@example.com', Date.now(), 0),
+      Git.Signature.create('committer', 'me@example.com', Date.now(), 0),
+      'second commit'
+    )
+
+    // Wait for deployment
+
+    while (file !== 'built again') {
+      try {
+        file = (await readFile(
+          resolve(destDirectory, 'repo', 'master', 'file')
+        )).toString()
+      } catch(e) {
+        await wait(1000)
+      }
+    }
+
+    // Leave a chance for status updates to finish
+
+    await wait(500)
+
+    // Stop peon
+
+    await peon.stop()
+  })
+})

--- a/test/unit/build/build.test.js
+++ b/test/unit/build/build.test.js
@@ -1,0 +1,1053 @@
+/* eslint-disable camelcase */
+
+const { assert } = require('chai')
+const { mkdir, readFile, stat, writeFile } = require('fs-extra')
+const yaml = require('js-yaml')
+const { resolve } = require('path')
+const {
+  lookup,
+  mock,
+  mockConfig,
+  root,
+  tempDir,
+  wait
+} = require('../../helpers')
+
+const { Build, BuildWarning, CancelBuild, Environment } = lookup()
+
+describe('unit | build/build', function() {
+  describe('Build._runStep', function() {
+    let stepLog
+
+    beforeEach(() => (stepLog = []))
+
+    async function runStep(step) {
+      mock('status', {
+        updateBuildStep(build, step, status, output) {
+          stepLog.push({ build, step, status, output })
+        }
+      })
+
+      let build = new Build('ID', { head_commit: { id: 'sha' } }, {})
+      await build._runStep('mystep', step)
+    }
+
+    it('runs step and updates build status', async function() {
+      await runStep(async() => {
+        stepLog.push('step start')
+        wait(20)
+        stepLog.push('step end')
+      })
+
+      assert.deepEqual(stepLog, [
+        {
+          build: 'ID',
+          output: undefined,
+          status: 'running',
+          step: 'mystep'
+        },
+        'step start',
+        'step end',
+        {
+          build: 'ID',
+          output: undefined,
+          status: 'success',
+          step: 'mystep'
+        }
+      ])
+    })
+
+    it('updates build status with step output', async function() {
+      await runStep(async() => {
+        wait(20)
+        return 'step output'
+      })
+
+      assert.equal(stepLog.pop().output, 'step output')
+    })
+
+    it('updates build status with output during step execution', async function() {
+      await runStep(async(updateOutput) => {
+        wait(20)
+        updateOutput('partial output')
+        wait(20)
+        return 'final output'
+      })
+
+      assert.deepEqual(stepLog, [
+        {
+          build: 'ID',
+          output: undefined,
+          status: 'running',
+          step: 'mystep'
+        },
+        {
+          build: 'ID',
+          output: 'partial output',
+          status: 'running',
+          step: 'mystep'
+        },
+        {
+          build: 'ID',
+          output: 'final output',
+          status: 'success',
+          step: 'mystep'
+        }
+      ])
+    })
+
+    it('sets step status as failed when step throws a BuildWarning', async function() {
+      await runStep(async() => {
+        wait(20)
+        throw new BuildWarning(new Error('oopsie!'))
+      })
+
+      assert.deepEqual(stepLog.pop(), {
+        build: 'ID',
+        output: 'oopsie!',
+        status: 'failed',
+        step: 'mystep'
+      })
+    })
+
+    it('sets step status as failed and throws when step throws an error', async function() {
+      try {
+        await runStep(async() => {
+          wait(20)
+          throw new Error('oopsie!')
+        })
+        assert.ok(false)
+      } catch(e) {
+        assert.ok(true)
+      }
+
+      assert.deepEqual(stepLog.pop(), {
+        build: 'ID',
+        output: 'oopsie!',
+        status: 'failed',
+        step: 'mystep'
+      })
+    })
+  })
+
+  describe('Build._updateRepository', function() {
+    let workingDirectory
+
+    beforeEach(async function() {
+      workingDirectory = await tempDir()
+      mockConfig('workingDirectory', workingDirectory)
+    })
+
+    it('opens and fetches origin when a local clone exists', async function() {
+      let openPath, fetchRemote
+      mock('Git', {
+        Repository: {
+          open(path) {
+            openPath = path
+            return {
+              fetch(remote) {
+                fetchRemote = remote
+              }
+            }
+          }
+        }
+      })
+
+      await new Build(
+        'ID',
+        { head_commit: { id: 'sha' } },
+        { name: 'reponame' }
+      )._updateRepository()
+
+      assert.equal(openPath, `${workingDirectory}/repos/reponame`)
+      assert.equal(fetchRemote, 'origin')
+    })
+
+    it('clones the repository when a local clone does not exist', async function() {
+      let log = []
+
+      mock('Git', {
+        Clone(url, path) {
+          log.push({ what: 'clone', url, path })
+
+          return {
+            fetch(remote) {
+              log.push({ what: 'fetch', remote })
+            }
+          }
+        },
+
+        Repository: {
+          open(path) {
+            log.push({ what: 'open', path })
+            throw new Error('nope')
+          }
+        }
+      })
+
+      await new Build(
+        'ID',
+        { head_commit: { id: 'sha' } },
+        { name: 'reponame', url: 'git://repo' }
+      )._updateRepository()
+
+      assert.deepEqual(log, [
+        { what: 'open', path: `${workingDirectory}/repos/reponame` },
+        {
+          what: 'clone',
+          url: 'git://repo',
+          path: `${workingDirectory}/repos/reponame`
+        }
+      ])
+    })
+  })
+
+  describe('Build._createWorkspace', function() {
+    let workingDirectory
+
+    beforeEach(async function() {
+      workingDirectory = await tempDir()
+      mockConfig('workingDirectory', workingDirectory)
+    })
+
+    it('clones the repo in a temp workspace and checks out the event SHA', async function() {
+      let log = []
+      mock('Git', {
+        Clone(source, dest) {
+          log.push({ what: 'clone', source, dest })
+
+          return {
+            createBranch(name, sha) {
+              log.push({ what: 'create branch', name, sha })
+              return 'myref'
+            },
+            checkoutRef(ref) {
+              log.push({ what: 'checkout', ref })
+            }
+          }
+        }
+      })
+
+      await new Build(
+        'ID',
+        { head_commit: { id: 'mysha' } },
+        { name: 'reponame' }
+      )._createWorkspace()
+
+      let firstLog = log.shift()
+      assert.equal(firstLog.what, 'clone')
+      assert.equal(firstLog.source, `${workingDirectory}/repos/reponame`)
+      assert.include(firstLog.dest, '/peon-workspace-reponame')
+
+      assert.deepEqual(log, [
+        { what: 'create branch', name: 'peon-build', sha: 'mysha' },
+        { what: 'checkout', ref: 'myref' }
+      ])
+    })
+  })
+
+  describe('Build._readPeonConfig', function() {
+    async function readPeonConfig(json, repoConfig) {
+      let build = new Build('ID', { head_commit: { id: 'mysha' } }, repoConfig)
+
+      build.start = new Date('2001-02-03T04:05:06Z')
+      build.workspace = await tempDir()
+
+      if (json) {
+        await writeFile(
+          resolve(build.workspace, '.peon.yml'),
+          yaml.safeDump(json)
+        )
+      }
+
+      await build._readPeonConfig()
+      return build
+    }
+
+    it('fails when .peon.yml is missing', async function() {
+      try {
+        await readPeonConfig(null, {})
+        assert.ok(false)
+      } catch(e) {
+        assert.equal(e.code, 'ENOENT')
+      }
+    })
+
+    it('fails when `output` is not a string', async function() {
+      for (let output of [null, {}, 1]) {
+        try {
+          await readPeonConfig({ output }, {})
+          assert.ok(false)
+        } catch(e) {
+          assert.equal(e.message, 'missing output parameter in .peon.yml')
+        }
+      }
+    })
+
+    it('fails when `commands` is not an array with items', async function() {
+      for (let commands of [null, 'string', []]) {
+        try {
+          await readPeonConfig({ output: 'dist', commands }, {})
+          assert.ok(false)
+        } catch(e) {
+          assert.equal(e.message, 'no build commands in .peon.yml')
+        }
+      }
+    })
+
+    it('fails when building a tag and `tags` is not present', async function() {
+      try {
+        await readPeonConfig(
+          { output: 'dist', commands: ['build'] },
+          { ref: 'mytag', refMode: 'tag' }
+        )
+        assert.ok(false)
+      } catch(e) {
+        assert.equal(e.message, 'tag mytag is not present in .peon.yml')
+      }
+    })
+
+    it('fails when building a tag and `tags` has no matching regexp', async function() {
+      try {
+        await readPeonConfig(
+          { output: 'dist', commands: ['build'], tags: ['^v', '^release'] },
+          { ref: 'mytag', refMode: 'tag' }
+        )
+        assert.ok(false)
+      } catch(e) {
+        assert.equal(e.message, 'tag mytag is not present in .peon.yml')
+      }
+    })
+
+    it('fails when building a branch and `branches` is present but has no matching regexp', async function() {
+      try {
+        await readPeonConfig(
+          {
+            output: 'dist',
+            commands: ['build'],
+            branches: ['^master$', '^feat/']
+          },
+          { ref: 'mybranch', refMode: 'branch' }
+        )
+        assert.ok(false)
+      } catch(e) {
+        assert.equal(e.message, 'branch mybranch is not present in .peon.yml')
+      }
+    })
+
+    it('fails when no destination is specified', async function() {
+      try {
+        await readPeonConfig(
+          {
+            output: 'dist',
+            commands: ['build']
+          },
+          { ref: 'mybranch', refMode: 'branch' }
+        )
+        assert.ok(false)
+      } catch(e) {
+        assert.equal(
+          e.message,
+          "could not find a destination matching branch 'mybranch' in .peon.yml"
+        )
+      }
+    })
+
+    it('fails when an unknown destination is specified', async function() {
+      mockConfig('destinations', { known: {} })
+      try {
+        await readPeonConfig(
+          {
+            output: 'dist',
+            commands: ['build'],
+            destinations: [{ name: 'unknown' }]
+          },
+          { ref: 'mybranch', refMode: 'branch' }
+        )
+        assert.ok(false)
+      } catch(e) {
+        assert.equal(
+          e.message,
+          "unknown build destination: 'unknown' in .peon.yml"
+        )
+      }
+    })
+
+    it('fails when building a tag and no matching destination is found', async function() {
+      mockConfig('destinations', { dest1: {}, dest2: {}, dest3: {} })
+      try {
+        await readPeonConfig(
+          {
+            output: 'dist',
+            commands: ['build'],
+            tags: ['mytag'],
+            destinations: [
+              { name: 'dest1', tag: '^release' },
+              { name: 'dest2', branch: '^master$' },
+              { name: 'dest3' }
+            ]
+          },
+          { ref: 'mytag', refMode: 'tag' }
+        )
+        assert.ok(false)
+      } catch(e) {
+        assert.equal(
+          e.message,
+          "could not find a destination matching tag 'mytag' in .peon.yml"
+        )
+      }
+    })
+
+    it('fails when building a branch and no matching destination is found', async function() {
+      mockConfig('destinations', { dest1: {}, dest2: {}, dest3: {} })
+      try {
+        await readPeonConfig(
+          {
+            output: 'dist',
+            commands: ['build'],
+            destinations: [
+              { name: 'dest1', tag: '^release' },
+              { name: 'dest2', branch: '^feat/' },
+              { name: 'dest3', tag: '^v', branch: '^chore/' }
+            ]
+          },
+          { ref: 'mybranch', refMode: 'branch' }
+        )
+        assert.ok(false)
+      } catch(e) {
+        assert.equal(
+          e.message,
+          "could not find a destination matching branch 'mybranch' in .peon.yml"
+        )
+      }
+    })
+
+    it('choses the first matching destination', async function() {
+      let dest1 = {}
+      let dest2 = { rootUrl: 'root' }
+      let dest3 = { rootUrl: 'root' }
+      mockConfig('destinations', { dest1, dest2, dest3 })
+
+      let build = await readPeonConfig(
+        {
+          output: 'dist',
+          commands: ['build'],
+          destinations: [
+            { name: 'dest1', path: 'path1', branch: '^master$' },
+            { name: 'dest2', path: 'path2', branch: '^my' },
+            { name: 'dest3', path: 'path3', branch: '^m' }
+          ]
+        },
+        { ref: 'mybranch', refMode: 'branch' }
+      )
+
+      assert.equal(build.destination, dest2)
+      assert.equal(build.pathInDestination, 'path2')
+
+      build = await readPeonConfig(
+        {
+          output: 'dist',
+          commands: ['build'],
+          destinations: [
+            { name: 'dest1', path: 'path1', branch: '^master$' },
+            { name: 'dest2', path: 'path2', tag: '^v' },
+            { name: 'dest3' }
+          ]
+        },
+        { ref: 'mybranch', refMode: 'branch' }
+      )
+
+      assert.equal(build.destination, dest3)
+      assert.equal(build.pathInDestination, '$PEON_REPO_NAME/$PEON_REF')
+
+      build = await readPeonConfig(
+        {
+          output: 'dist',
+          commands: ['build'],
+          tags: ['mytag'],
+          destinations: [
+            { name: 'dest1', path: 'path1' },
+            { name: 'dest2', path: 'path2', branch: '^master$', tag: '^my' },
+            { name: 'dest3', path: 'path3', tag: '^m' }
+          ]
+        },
+        { ref: 'mytag', refMode: 'tag' }
+      )
+
+      assert.equal(build.destination, dest2)
+      assert.equal(build.pathInDestination, 'path2')
+    })
+
+    it('fails when chosen destination has a relative part', async function() {
+      mockConfig('destinations', { dest1: {} })
+
+      try {
+        await readPeonConfig(
+          {
+            output: 'dist',
+            commands: ['build'],
+            destinations: [{ name: 'dest1', path: '../path' }]
+          },
+          { ref: 'mybranch', refMode: 'branch' }
+        )
+        assert.ok(false)
+      } catch(e) {
+        assert.equal(
+          e.message,
+          "invalid relative destination path '../path' (resolves to '../path') in .peon.yml"
+        )
+      }
+    })
+
+    it('creates environment with peon variables and config from repo when building a branch', async function() {
+      mockConfig('destinations', { dest1: { rootUrl: '/root/url' } })
+      let receivedEnv
+
+      mock(
+        'Environment',
+        class {
+          constructor(env) {
+            receivedEnv = env
+          }
+        }
+      )
+
+      await readPeonConfig(
+        {
+          output: 'dist',
+          commands: ['build'],
+          destinations: [{ name: 'dest1', path: 'path1' }],
+          environment: { var1: 'value1', var2: 'value2' }
+        },
+        { name: 'reponame', ref: 'mybranch', refMode: 'branch' }
+      )
+
+      assert.deepEqual(receivedEnv, {
+        PEON_BUILD_ID: 'ID',
+        PEON_BUILD_DATE: '2001-02-03T04:05:06.000Z',
+        PEON_ROOT_URL: '/root/url/path1',
+        PEON_REPO_NAME: 'reponame',
+        PEON_BRANCH: 'mybranch',
+        PEON_TAG: '',
+        PEON_REF: 'mybranch',
+        PEON_COMMIT: 'mysha',
+        var1: 'value1',
+        var2: 'value2'
+      })
+    })
+
+    it('creates environment with peon variables and config from repo when building a tag', async function() {
+      mockConfig('destinations', { dest1: { rootUrl: '/root/url' } })
+      let receivedEnv
+
+      mock(
+        'Environment',
+        class {
+          constructor(env) {
+            receivedEnv = env
+          }
+        }
+      )
+
+      await readPeonConfig(
+        {
+          output: 'dist',
+          commands: ['build'],
+          tags: ['mytag'],
+          destinations: [{ name: 'dest1', tag: '^my' }],
+          environment: { var1: 'value1', var2: 'value2' }
+        },
+        { name: 'reponame', ref: 'mytag', refMode: 'tag' }
+      )
+
+      assert.deepEqual(receivedEnv, {
+        PEON_BUILD_ID: 'ID',
+        PEON_BUILD_DATE: '2001-02-03T04:05:06.000Z',
+        PEON_ROOT_URL: '/root/url/$PEON_REPO_NAME/$PEON_REF',
+        PEON_REPO_NAME: 'reponame',
+        PEON_BRANCH: '',
+        PEON_TAG: 'mytag',
+        PEON_REF: 'mytag',
+        PEON_COMMIT: 'mysha',
+        var1: 'value1',
+        var2: 'value2'
+      })
+    })
+  })
+
+  describe('Build._restoreCache', function() {
+    it('calls restoreCache and returns restored paths', async function() {
+      let build = new Build(
+        'ID',
+        { head_commit: { id: 'sha' } },
+        { name: 'reponame' }
+      )
+
+      build.peonConfig = { cache: 'cache' }
+      build.workspace = 'workspace'
+
+      let restoreCacheArgs
+      mock('cache', {
+        restoreCache() {
+          restoreCacheArgs = [...arguments]
+          return ['path1', 'path2']
+        }
+      })
+
+      let ret = await build._restoreCache()
+      assert.deepEqual(restoreCacheArgs, ['reponame', 'workspace', 'cache'])
+      assert.equal(ret, 'restored paths path1, path2')
+    })
+
+    it('throws a BuildWarning when an error happens', async function() {
+      let build = new Build(
+        'ID',
+        { head_commit: { id: 'sha' } },
+        { name: 'reponame' }
+      )
+
+      build.peonConfig = {}
+
+      mock('cache', {
+        restoreCache() {
+          throw new Error('oopsie!')
+        }
+      })
+
+      try {
+        await build._restoreCache()
+        assert.ok(false)
+      } catch(e) {
+        assert.instanceOf(e, lookup('BuildWarning'))
+        assert.equal(e.message, 'oopsie!')
+      }
+    })
+  })
+
+  describe('Build._saveCache', function() {
+    it('calls saveCache and returns saved paths', async function() {
+      let build = new Build(
+        'ID',
+        { head_commit: { id: 'sha' } },
+        { name: 'reponame' }
+      )
+
+      build.peonConfig = { cache: 'cache' }
+      build.workspace = 'workspace'
+
+      let saveCacheArgs
+      mock('cache', {
+        saveCache() {
+          saveCacheArgs = [...arguments]
+          return ['path1', 'path2']
+        }
+      })
+
+      let ret = await build._saveCache()
+      assert.deepEqual(saveCacheArgs, ['reponame', 'workspace', 'cache'])
+      assert.equal(ret, 'saved paths path1, path2')
+    })
+
+    it('throws a BuildWarning when an error happens', async function() {
+      let build = new Build(
+        'ID',
+        { head_commit: { id: 'sha' } },
+        { name: 'reponame' }
+      )
+
+      build.peonConfig = {}
+
+      mock('cache', {
+        saveCache() {
+          throw new Error('oopsie!')
+        }
+      })
+
+      try {
+        await build._saveCache()
+        assert.ok(false)
+      } catch(e) {
+        assert.instanceOf(e, lookup('BuildWarning'))
+        assert.equal(e.message, 'oopsie!')
+      }
+    })
+  })
+
+  describe('Build._runCommand', function() {
+    it('runs command and reports output', async function() {
+      this.slow(300)
+
+      let build = new Build('ID', { head_commit: { id: 'sha' } }, {})
+      build.env = new Environment()
+      build.workspace = await tempDir()
+
+      let updates = []
+
+      let output = await build._runCommand(
+        resolve(root, 'scripts', 'test_command'),
+        (out) => updates.push(out)
+      )
+
+      assert.deepEqual(output.split('\n'), [
+        '[stdout] output line 1',
+        '[stdout] output line 2',
+        '[stderr] error line',
+        '[stdout] output line 3',
+        ''
+      ])
+
+      assert.deepEqual(updates, [
+        '[stdout] output line 1\n',
+        '[stdout] output line 1\n[stdout] output line 2\n',
+        '[stdout] output line 1\n[stdout] output line 2\n[stderr] error line\n',
+        '[stdout] output line 1\n[stdout] output line 2\n[stderr] error line\n[stdout] output line 3\n'
+      ])
+    })
+
+    it('passes workspace as working directory', async function() {
+      let build = new Build('ID', { head_commit: { id: 'sha' } }, {})
+      build.env = new Environment({})
+      build.workspace = await tempDir()
+
+      let output = await build._runCommand('pwd', () => {})
+
+      assert.deepEqual(output, `[stdout] ${build.workspace}\n`)
+    })
+
+    it('passes evaluated environment', async function() {
+      let build = new Build('ID', { head_commit: { id: 'sha' } }, {})
+      build.env = new Environment({
+        VAR1: 'VALUE',
+        VAR2: 'EVALUATED/$VAR1'
+      })
+      build.workspace = await tempDir()
+
+      let output = await build._runCommand('env', () => {})
+
+      let envLines = output.replace(/\[stdout\] /g, '').split('\n')
+      assert.include(envLines, 'VAR1=VALUE')
+      assert.include(envLines, 'VAR2=EVALUATED/VALUE')
+    })
+
+    it('fails when command fails', async function() {
+      this.slow(300)
+
+      let build = new Build('ID', { head_commit: { id: 'sha' } }, {})
+      build.env = new Environment({})
+      build.workspace = await tempDir()
+
+      try {
+        await build._runCommand(
+          resolve(root, 'scripts', 'test_command fail'),
+          () => {}
+        )
+        assert.ok(false)
+      } catch(e) {
+        assert.include(e.message, 'exited with error code 1')
+      }
+    })
+  })
+
+  describe('Build._deploy', function() {
+    it('fails when output directory is not found', async function() {
+      let build = new Build('ID', { head_commit: { id: 'sha' } }, {})
+
+      build.env = new Environment({})
+      build.pathInDestination = 'path'
+      build.peonConfig = { output: 'missing' }
+      build.workspace = await tempDir()
+
+      try {
+        await build._deploy()
+        assert.ok(false)
+      } catch(e) {
+        assert.include(e.message, "output directory 'missing' not found")
+      }
+    })
+
+    it('fails when output is not a directory', async function() {
+      let build = new Build('ID', { head_commit: { id: 'sha' } }, {})
+
+      build.env = new Environment({})
+      build.pathInDestination = 'path'
+      build.peonConfig = { output: 'file' }
+      build.workspace = await tempDir()
+
+      await writeFile(resolve(build.workspace, 'file'), 'content')
+
+      try {
+        await build._deploy()
+        assert.ok(false)
+      } catch(e) {
+        assert.include(e.message, "output 'file' is not a directory")
+      }
+    })
+
+    it('deploys locally, creating intermediate directories', async function() {
+      let build = new Build('ID', { head_commit: { id: 'sha' } }, {})
+
+      build.env = new Environment({ VAR: 'from_env' })
+      build.destination = {
+        destination: await tempDir()
+      }
+      build.pathInDestination = 'path/in/destination/$VAR'
+      build.peonConfig = { output: 'output' }
+      build.workspace = await tempDir()
+
+      await mkdir(resolve(build.workspace, 'output'))
+
+      let rsync = { options: [] }
+      mock(
+        'Rsync',
+        class {
+          set(option) {
+            rsync.options.push(option)
+            return this
+          }
+          source(src) {
+            rsync.src = src
+            return this
+          }
+          destination(dst) {
+            rsync.dst = dst
+            return this
+          }
+          shell(sh) {
+            rsync.sh = sh
+            return this
+          }
+          command() {
+            return 'rsync command'
+          }
+          execute(cb) {
+            rsync.executed = true
+            cb()
+          }
+        }
+      )
+
+      await build._deploy()
+
+      assert.ok(
+        (await stat(
+          resolve(build.destination.destination, 'path/in/destination')
+        )).isDirectory()
+      )
+
+      assert.deepEqual(rsync, {
+        options: ['partial', 'recursive', 'compress'],
+        src: `${resolve(build.workspace, 'output')}/`,
+        dst: `${resolve(
+          build.destination.destination,
+          'path/in/destination/from_env'
+        )}/`,
+        executed: true
+      })
+    })
+
+    it('deploys remotely, moving output to create intermediate directories', async function() {
+      let build = new Build(
+        'ID',
+        { head_commit: { id: 'sha' } },
+        { name: 'reponame' }
+      )
+
+      build.env = new Environment({ VAR: 'from_env' })
+      build.destination = {
+        destination: 'user@host:path/to/dest',
+        shell: 'someshell'
+      }
+      build.pathInDestination = 'path/in/destination/$VAR'
+      build.peonConfig = { output: 'output' }
+      build.workspace = await tempDir()
+
+      await mkdir(resolve(build.workspace, 'output'))
+      await writeFile(resolve(build.workspace, 'output', 'file'), 'content')
+
+      let rsync = { options: [] }
+      let outputMoved = false
+
+      mock(
+        'Rsync',
+        class {
+          set(option) {
+            rsync.options.push(option)
+            return this
+          }
+          source(src) {
+            rsync.src = src
+            return this
+          }
+          destination(dst) {
+            rsync.dst = dst
+            return this
+          }
+          shell(sh) {
+            rsync.sh = sh
+            return this
+          }
+          command() {
+            return 'rsync command'
+          }
+          execute(cb) {
+            rsync.executed = true
+
+            readFile(`${rsync.src}path/in/destination/from_env/file`)
+              .then((content) => {
+                outputMoved = content.toString() === 'content'
+                cb()
+              })
+              .catch((e) => cb(e))
+          }
+        }
+      )
+
+      await build._deploy()
+
+      assert.ok(outputMoved)
+
+      let { src } = rsync
+      assert.ok(src.match(/\/peon-output-reponame-\w+\/$/))
+
+      assert.deepEqual(rsync, {
+        options: ['partial', 'recursive', 'compress'],
+        src,
+        dst: 'user@host:path/to/dest/',
+        sh: 'someshell',
+        executed: true
+      })
+    })
+
+    it('fails when rsync throws an error', async function() {
+      let build = new Build('ID', { head_commit: { id: 'sha' } }, {})
+
+      build.env = new Environment({})
+      build.destination = {
+        destination: await tempDir()
+      }
+      build.pathInDestination = 'path/in/destination'
+      build.peonConfig = { output: 'output' }
+      build.workspace = await tempDir()
+
+      await mkdir(resolve(build.workspace, 'output'))
+
+      mock(
+        'Rsync',
+        class {
+          set() {
+            return this
+          }
+          source() {
+            return this
+          }
+          destination() {
+            return this
+          }
+          command() {
+            return 'rsync command'
+          }
+          execute(cb) {
+            cb(new Error('oopsie'))
+          }
+        }
+      )
+
+      try {
+        await build._deploy()
+        assert.ok(false)
+      } catch(e) {
+        assert.include(e.message, 'oopsie')
+      }
+    })
+  })
+
+  describe('Build.build', function() {
+    async function runBuild(peonConfig = {}, fail = false, cancel = false) {
+      let log = []
+
+      mock('status', {
+        finishBuild() {
+          log.push({ what: 'finish', args: [...arguments] })
+        }
+      })
+
+      let build = new Build('ID', { head_commit: { id: 'sha' } }, {})
+
+      build.env = new Environment({ VAR: 'value' })
+      build.destination = { absoluteUrl: 'https://example.com/url' }
+      build.peonConfig = peonConfig
+      build.pathInDestination = 'path/$VAR'
+
+      build._runStep = function(_, step) {
+        log.push({ what: 'step', step: step() })
+      }
+      build._updateRepository = fail
+        ? () => {
+          throw new Error('oopsie')
+        }
+        : () => 'update repository'
+      build._createWorkspace = () => 'create workspace'
+      build._readPeonConfig = cancel
+        ? () => {
+          throw new CancelBuild()
+        }
+        : () => 'read peon config'
+      build._restoreCache = () => 'restore cache'
+      build._runCommand = (cmd) => `run ${cmd}`
+      build._saveCache = () => 'save cache'
+      build._deploy = () => 'deploy'
+
+      await build.build()
+
+      return log
+    }
+
+    it('runs steps and updates status', async function() {
+      let log = await runBuild({ commands: ['cmd1', 'cmd2'], cache: [{}] })
+
+      assert.deepEqual(log, [
+        { what: 'step', step: 'update repository' },
+        { what: 'step', step: 'create workspace' },
+        { what: 'step', step: 'read peon config' },
+        { what: 'step', step: 'restore cache' },
+        { what: 'step', step: 'run cmd1' },
+        { what: 'step', step: 'run cmd2' },
+        { what: 'step', step: 'save cache' },
+        { what: 'step', step: 'deploy' },
+        {
+          what: 'finish',
+          args: [
+            'ID',
+            'success',
+            { outputURL: 'https://example.com/url/path/value' }
+          ]
+        }
+      ])
+    })
+
+    it('does not save/restore cache without cache entries', async function() {
+      let log = await runBuild({ commands: ['build'] })
+
+      assert.notOk(log.find((l) => l.step === 'restore cache'))
+      assert.notOk(log.find((l) => l.step === 'save cache'))
+    })
+
+    it('sets build as failed when a step throws', async function() {
+      let log = await runBuild({ commands: ['build'] }, true)
+
+      assert.deepEqual(log.find((l) => l.what === 'finish'), {
+        what: 'finish',
+        args: ['ID', 'failed']
+      })
+    })
+
+    it('sets build as cancelled when a step throws a CancelBuild', async function() {
+      let log = await runBuild({ commands: ['build'] }, false, true)
+
+      assert.deepEqual(log.find((l) => l.what === 'finish'), {
+        what: 'finish',
+        args: ['ID', 'cancelled']
+      })
+    })
+  })
+})

--- a/test/unit/build/cache.test.js
+++ b/test/unit/build/cache.test.js
@@ -1,0 +1,295 @@
+const { assert } = require('chai')
+const { mkdir, readdir, utimes, writeFile } = require('fs-extra')
+const { resolve } = require('path')
+const crypto = require('crypto')
+const { lookup, mock, mockConfig, tempDir } = require('../../helpers')
+
+const { Cache } = lookup()
+
+describe('unit | build/cache', function() {
+  let workingDirectory
+
+  beforeEach(async function() {
+    workingDirectory = await tempDir()
+    mockConfig('workingDirectory', workingDirectory)
+  })
+
+  describe('Cache._getCacheFilename', function() {
+    it('returns nothing when key file does not exist', async function() {
+      assert.equal(
+        await new Cache()._getCacheFilename('myrepo', workingDirectory, {
+          path: 'some/path/to/cache',
+          source: 'nonexistingfile'
+        }),
+        undefined
+      )
+    })
+
+    it('returns a filename based on key file content', async function() {
+      let markerContent = 'some content'
+      await writeFile(resolve(workingDirectory, 'markerfile'), markerContent)
+
+      let sha = crypto
+        .createHash('sha256')
+        .update(markerContent)
+        .digest('hex')
+
+      let entry = {
+        path: 'some/path/to/cache',
+        source: 'markerfile'
+      }
+
+      assert.equal(
+        await new Cache()._getCacheFilename('myrepo', workingDirectory, entry),
+        `myrepo-some_path_to_cache-${sha}.tar`
+      )
+
+      assert.equal(entry.digest, sha)
+    })
+
+    it('does not recompute digest when already computed', async function() {
+      let entry = {
+        digest: 'somedigest',
+        path: 'some/path/to/cache',
+        source: 'markerfile'
+      }
+
+      assert.equal(
+        await new Cache()._getCacheFilename('myrepo', workingDirectory, entry),
+        'myrepo-some_path_to_cache-somedigest.tar'
+      )
+    })
+  })
+
+  describe('Cache._pruneCache', function() {
+    it('removes expired entries', async function() {
+      let validitySeconds = 60
+      let expiredUnixTime = Date.now() / 1000 - validitySeconds * 2
+      let validUnixTime = Date.now() / 1000 - validitySeconds / 2
+
+      mockConfig('cacheValidity', validitySeconds * 1000)
+
+      let cache = new Cache()
+      await cache._ensureCacheDirExists()
+
+      await writeFile(resolve(workingDirectory, 'cache', 'expired'), 'content')
+      await utimes(
+        resolve(workingDirectory, 'cache', 'expired'),
+        expiredUnixTime,
+        expiredUnixTime
+      )
+      await writeFile(resolve(workingDirectory, 'cache', 'valid1'), 'content')
+      await utimes(
+        resolve(workingDirectory, 'cache', 'valid1'),
+        validUnixTime,
+        validUnixTime
+      )
+      await writeFile(resolve(workingDirectory, 'cache', 'valid2'), 'content')
+
+      await cache._pruneCache()
+
+      assert.deepEqual(await readdir(resolve(workingDirectory, 'cache')), [
+        'valid1',
+        'valid2'
+      ])
+    })
+  })
+
+  describe('Cache.saveCache', function() {
+    it('does nothing when no cache entries are present', async function() {
+      assert.deepEqual(await new Cache().saveCache('myrepo', 'myroot', []), [])
+    })
+
+    it('does nothing when entry path does not exist', async function() {
+      await writeFile(resolve(workingDirectory, 'existingkeyfile'), 'key')
+      assert.deepEqual(
+        await new Cache().saveCache('myrepo', workingDirectory, [
+          {
+            path: 'missingpath',
+            source: 'existingkeyfile'
+          }
+        ]),
+        []
+      )
+    })
+
+    it('does nothing when key file does not exist', async function() {
+      await mkdir(resolve(workingDirectory, 'existingpath'))
+      assert.deepEqual(
+        await new Cache().saveCache('myrepo', workingDirectory, [
+          {
+            path: 'existingpath',
+            source: 'missingkeyfile'
+          }
+        ]),
+        []
+      )
+    })
+
+    it('does nothing when matching archive already exists', async function() {
+      let cache = new Cache()
+      let sha = crypto
+        .createHash('sha256')
+        .update('key')
+        .digest('hex')
+
+      await writeFile(resolve(workingDirectory, 'existingkeyfile'), 'key')
+
+      await cache._ensureCacheDirExists()
+      await writeFile(
+        resolve(workingDirectory, 'cache', `myrepo-existingpath-${sha}.tar`),
+        'dummy'
+      )
+      await mkdir(resolve(workingDirectory, 'existingpath'))
+
+      assert.deepEqual(
+        await cache.saveCache('myrepo', workingDirectory, [
+          {
+            path: 'existingpath',
+            source: 'existingkeyfile'
+          }
+        ]),
+        []
+      )
+    })
+
+    it('creates cache archives', async function() {
+      let tarCalls = []
+      mock('Tar', {
+        here: 'heeeere',
+        create({ cwd, file }, paths) {
+          tarCalls.push({ cwd, file, paths })
+        }
+      })
+
+      let cache = new Cache()
+      let sha = crypto
+        .createHash('sha256')
+        .update('key')
+        .digest('hex')
+
+      await writeFile(resolve(workingDirectory, 'existingkeyfile'), 'key')
+      await mkdir(resolve(workingDirectory, 'existingpath'))
+
+      assert.deepEqual(
+        await cache.saveCache('myrepo', workingDirectory, [
+          { path: 'existingpath', source: 'existingkeyfile' },
+          { path: 'nonexistingpath', source: 'existingkeyfile' },
+          { path: 'existingpath', source: 'nonexistingkeyfile' }
+        ]),
+        ['existingpath']
+      )
+
+      assert.deepEqual(tarCalls, [
+        {
+          cwd: workingDirectory,
+          file: resolve(
+            workingDirectory,
+            'cache',
+            `myrepo-existingpath-${sha}.tar`
+          ),
+          paths: ['existingpath']
+        }
+      ])
+    })
+  })
+
+  describe('Cache.restoreCache', function() {
+    it('does nothing when no cache entries are present', async function() {
+      assert.deepEqual(
+        await new Cache().restoreCache('myrepo', 'myroot', []),
+        []
+      )
+    })
+
+    it('does nothing when entry path does not exist', async function() {
+      await writeFile(resolve(workingDirectory, 'existingkeyfile'), 'key')
+      assert.deepEqual(
+        await new Cache().restoreCache('myrepo', workingDirectory, [
+          {
+            path: 'missingpath',
+            source: 'existingkeyfile'
+          }
+        ]),
+        []
+      )
+    })
+
+    it('does nothing when key file does not exist', async function() {
+      await mkdir(resolve(workingDirectory, 'existingpath'))
+      assert.deepEqual(
+        await new Cache().restoreCache('myrepo', workingDirectory, [
+          {
+            path: 'existingpath',
+            source: 'missingkeyfile'
+          }
+        ]),
+        []
+      )
+    })
+
+    it('does nothing when matching archive does not exists', async function() {
+      let cache = new Cache()
+
+      await writeFile(resolve(workingDirectory, 'existingkeyfile'), 'key')
+
+      await cache._ensureCacheDirExists()
+      await mkdir(resolve(workingDirectory, 'existingpath'))
+
+      assert.deepEqual(
+        await cache.restoreCache('myrepo', workingDirectory, [
+          {
+            path: 'existingpath',
+            source: 'existingkeyfile'
+          }
+        ]),
+        []
+      )
+    })
+
+    it('extracts cache archives', async function() {
+      let tarCalls = []
+      mock('Tar', {
+        here: 'heeeere',
+        extract({ cwd, file }) {
+          tarCalls.push({ cwd, file })
+        }
+      })
+
+      let cache = new Cache()
+      let sha = crypto
+        .createHash('sha256')
+        .update('key')
+        .digest('hex')
+
+      await cache._ensureCacheDirExists()
+      await writeFile(
+        resolve(workingDirectory, 'cache', `myrepo-existingpath-${sha}.tar`),
+        'dummy'
+      )
+
+      await writeFile(resolve(workingDirectory, 'existingkeyfile'), 'key')
+      await mkdir(resolve(workingDirectory, 'existingpath'))
+
+      assert.deepEqual(
+        await cache.restoreCache('myrepo', workingDirectory, [
+          { path: 'existingpath', source: 'existingkeyfile' },
+          { path: 'nonexistingpath', source: 'existingkeyfile' },
+          { path: 'existingpath', source: 'nonexistingkeyfile' }
+        ]),
+        ['existingpath']
+      )
+
+      assert.deepEqual(tarCalls, [
+        {
+          cwd: workingDirectory,
+          file: resolve(
+            workingDirectory,
+            'cache',
+            `myrepo-existingpath-${sha}.tar`
+          )
+        }
+      ])
+    })
+  })
+})

--- a/test/unit/build/dispatcher.test.js
+++ b/test/unit/build/dispatcher.test.js
@@ -1,0 +1,210 @@
+/* eslint-disable camelcase */
+
+const { assert } = require('chai')
+const { lookup, mock, mockConfig } = require('../../helpers')
+
+const { Dispatcher } = lookup()
+
+describe('unit | build/dispatcher', function() {
+  describe('Dispatcher.findRepository', function() {
+    it('ignores non push events', function() {
+      mockConfig('watcher', {})
+      mockConfig('webhooks', {})
+
+      assert.equal(new Dispatcher().findRepository('foo'), null)
+    })
+
+    it('ignores non-branch, non-tag refs', function() {
+      mockConfig('watcher', {})
+      mockConfig('webhooks', {})
+
+      let payload = {
+        ref: 'refs/foos/bar',
+        repository: {}
+      }
+
+      assert.equal(new Dispatcher().findRepository('push', payload), null)
+    })
+
+    it('ignores events when watcher and webhooks are disabled', function() {
+      mockConfig('watcher', {})
+      mockConfig('webhooks', {})
+
+      let payload = {
+        ref: 'refs/heads/mybranch',
+        repository: { ssh_url: 'git@example.com:org/repo' }
+      }
+
+      assert.equal(new Dispatcher().findRepository('push', payload), null)
+    })
+
+    it('extracts info from branch push webhook', function() {
+      mockConfig('watcher', {})
+      mockConfig('webhooks', { enabled: true })
+
+      let payload = {
+        ref: 'refs/heads/mybranch',
+        repository: { ssh_url: 'git@example.com:org/repo' }
+      }
+
+      assert.deepEqual(new Dispatcher().findRepository('push', payload), {
+        name: 'repo',
+        url: 'git@example.com:org/repo',
+        refMode: 'branch',
+        ref: 'mybranch'
+      })
+    })
+
+    it('extracts info from tag push webhook', function() {
+      mockConfig('watcher', {})
+      mockConfig('webhooks', { enabled: true })
+
+      let payload = {
+        ref: 'refs/tags/mytag',
+        repository: { ssh_url: 'git@example.com:org/repo' }
+      }
+
+      assert.deepEqual(new Dispatcher().findRepository('push', payload), {
+        name: 'repo',
+        url: 'git@example.com:org/repo',
+        refMode: 'tag',
+        ref: 'mytag'
+      })
+    })
+
+    it('ignores events from non-watched repo', function() {
+      mockConfig('watcher', { enabled: true, repositories: [] })
+      mockConfig('webhooks', {})
+
+      let payload = {
+        ref: 'refs/heads/mybranch',
+        repository: { ssh_url: 'git@example.com:org/repo' }
+      }
+
+      assert.equal(new Dispatcher().findRepository('push', payload), null)
+    })
+
+    it('ignores events from unknown branch in watched repo', function() {
+      mockConfig('watcher', {
+        enabled: true,
+        repositories: [
+          {
+            url: 'git@example.com:org/repo',
+            branches: ['branch1', 'branch2']
+          }
+        ]
+      })
+      mockConfig('webhooks', {})
+
+      let payload = {
+        ref: 'refs/heads/mybranch',
+        repository: { ssh_url: 'git@example.com:org/repo' }
+      }
+
+      assert.equal(new Dispatcher().findRepository('push', payload), null)
+    })
+
+    it('returns info from known branch in watched repo', function() {
+      mockConfig('watcher', {
+        enabled: true,
+        repositories: [
+          {
+            url: 'git@example.com:org/repo',
+            branches: ['branch1', 'branch2']
+          }
+        ]
+      })
+      mockConfig('webhooks', {})
+
+      let payload = {
+        ref: 'refs/heads/branch1',
+        repository: { ssh_url: 'git@example.com:org/repo' }
+      }
+
+      assert.deepEqual(new Dispatcher().findRepository('push', payload), {
+        branches: ['branch1', 'branch2'],
+        name: 'repo',
+        url: 'git@example.com:org/repo',
+        refMode: 'branch',
+        ref: 'branch1'
+      })
+    })
+  })
+
+  describe('Dispatcher.dispatch', function() {
+    it('does not do anything when findRepository returns null', async function() {
+      let startBuildCalled
+
+      mock('status', {
+        startBuild() {
+          startBuildCalled = true
+        }
+      })
+
+      let dispatcher = new Dispatcher()
+      dispatcher.findRepository = () => null
+      await dispatcher.dispatch('push', {})
+
+      assert.notOk(startBuildCalled)
+    })
+
+    it('starts a build and enqueues it when findRepository returns stuff', async function() {
+      let buildCtorArgs, buildCalled, startBuildArgs, queuedFunction
+
+      mock(
+        'Build',
+        class Build {
+          constructor() {
+            buildCtorArgs = [...arguments]
+          }
+
+          async build() {
+            buildCalled = true
+          }
+        }
+      )
+
+      mock('status', {
+        async startBuild() {
+          startBuildArgs = [...arguments]
+          return 'buildID'
+        }
+      })
+
+      mock(
+        'Queue',
+        class Queue {
+          run(fun) {
+            queuedFunction = fun
+          }
+        }
+      )
+
+      let repoConfig = {
+        name: 'repo',
+        url: 'git@example.com:org/repo',
+        refMode: 'branch',
+        ref: 'mybranch'
+      }
+
+      let payload = { head_commit: { id: 'shashasha' } }
+
+      let dispatcher = new Dispatcher()
+      dispatcher.findRepository = () => repoConfig
+
+      await dispatcher.dispatch('push', payload)
+
+      assert.deepEqual(startBuildArgs, [
+        'git@example.com:org/repo',
+        'repo',
+        'branch',
+        'mybranch',
+        'shashasha'
+      ])
+      assert.deepEqual(buildCtorArgs, ['buildID', payload, repoConfig])
+      assert.ok(queuedFunction)
+      await queuedFunction()
+      assert.ok(buildCalled)
+    })
+  })
+})

--- a/test/unit/injections.test.js
+++ b/test/unit/injections.test.js
@@ -1,0 +1,69 @@
+const { assert } = require('chai')
+const { src } = require('../helpers')
+const { register, registerLazy, lookup } = require(`${src}/injections`)
+
+describe('unit | injections', function() {
+  it('registers modules', function() {
+    register('foo', 'bar')
+
+    assert.equal(lookup('foo'), 'bar')
+  })
+
+  it('overrides registered modules', function() {
+    register('foo', 'bar')
+    register('foo', 'baz')
+
+    assert.equal(lookup('foo'), 'baz')
+  })
+
+  it('registers constructors', function() {
+    class Foo {}
+    register(Foo)
+    assert.equal(lookup('Foo'), Foo)
+  })
+
+  it('lookups with shorthand syntax', function() {
+    class Foo {}
+    register(Foo)
+    register('foo', 'bar')
+
+    let { foo, Foo: Foo2 } = lookup()
+    assert.equal(Foo2, Foo)
+    assert.equal(foo, 'bar')
+  })
+
+  it('registers with lazy getter', function() {
+    let called = 0
+    registerLazy('foo', () => {
+      called++
+      return 'bar'
+    })
+
+    assert.equal(called, 0)
+    assert.equal(lookup('foo'), 'bar')
+    let { foo } = lookup()
+    assert.equal(foo, 'bar')
+    lookup('foo')
+    assert.equal(called, 1)
+  })
+
+  it('overrides lazy registered modules', function() {
+    let called1 = 0
+    registerLazy('foo', () => {
+      called1++
+      return 'bar'
+    })
+
+    lookup('foo')
+
+    let called2 = 0
+    registerLazy('foo', () => {
+      called2++
+      return 'baz'
+    })
+
+    assert.equal(lookup('foo'), 'baz')
+    assert.equal(called1, 1)
+    assert.equal(called2, 1)
+  })
+})

--- a/test/unit/peon.test.js
+++ b/test/unit/peon.test.js
@@ -1,0 +1,195 @@
+/* eslint-disable camelcase */
+
+const { assert } = require('chai')
+const { src, mock, mockConfig } = require('../helpers')
+const Peon = require(`${src}/peon`)
+
+describe('unit | peon', function() {
+  describe('watchers', function() {
+    it('starts a watcher for each configured repository', async function() {
+      let watchers = []
+      mock(
+        'Watcher',
+        class {
+          constructor() {
+            this.info = { args: [...arguments] }
+            watchers.push(this.info)
+          }
+          on() {}
+          start() {
+            this.info.started = true
+          }
+        }
+      )
+
+      mockConfig('watcher', {
+        enabled: true,
+        repositories: [
+          { url: 'url/to/repo1', branches: ['a', 'b'] },
+          { url: 'url/to/repo2', branches: ['c', 'd'] }
+        ]
+      })
+
+      mockConfig('webhooks', { enabled: false })
+
+      await new Peon().start()
+
+      assert.deepEqual(watchers, [
+        { args: ['repo1', 'url/to/repo1', ['a', 'b']], started: true },
+        { args: ['repo2', 'url/to/repo2', ['c', 'd']], started: true }
+      ])
+    })
+
+    it('plugs dispatcher to watcher change events', async function() {
+      let handlers = {}
+      mock(
+        'Watcher',
+        class {
+          on(ev, handler) {
+            handlers[ev] = handler
+          }
+          start() {}
+        }
+      )
+
+      let dispatched
+      mock('dispatcher', {
+        dispatch() {
+          dispatched = [...arguments]
+        }
+      })
+
+      mockConfig('watcher', {
+        enabled: true,
+        repositories: [{ url: 'url/to/repo1', branches: ['a', 'b'] }]
+      })
+
+      mockConfig('webhooks', { enabled: false })
+
+      await new Peon().start()
+
+      assert.ok(handlers.change)
+      handlers.change('REF', 'SHA')
+
+      assert.deepEqual(dispatched, [
+        'push',
+        {
+          ref: 'REF',
+          head_commit: { id: 'SHA' },
+          repository: {
+            ssh_url: 'url/to/repo1'
+          }
+        }
+      ])
+    })
+
+    it('does not start watchers when disabled', async function() {
+      let watchers = []
+      mock(
+        'Watcher',
+        class {
+          constructor() {
+            watchers.push(this)
+          }
+        }
+      )
+
+      mockConfig('watcher', {
+        enabled: false,
+        repositories: [
+          { url: 'url/to/repo1', branches: ['a', 'b'] },
+          { url: 'url/to/repo2', branches: ['c', 'd'] }
+        ]
+      })
+
+      mockConfig('webhooks', { enabled: false })
+
+      await new Peon().start()
+
+      assert.deepEqual(watchers, [])
+    })
+  })
+
+  describe('webhooks', function() {
+    it('starts webhook server when enabled', async function() {
+      let created, started
+      mock(
+        'WebhookServer',
+        class {
+          constructor() {
+            created = true
+          }
+          on() {}
+          start() {
+            started = true
+          }
+        }
+      )
+
+      mockConfig('watcher', {
+        enabled: false
+      })
+
+      mockConfig('webhooks', { enabled: true })
+
+      await new Peon().start()
+
+      assert.ok(created && started)
+    })
+
+    it('plugs dispatcher to webhooks server push events', async function() {
+      let handlers = {}
+      mock(
+        'WebhookServer',
+        class {
+          on(ev, handler) {
+            handlers[ev] = handler
+          }
+          start() {}
+        }
+      )
+
+      let dispatched
+      mock('dispatcher', {
+        dispatch() {
+          dispatched = [...arguments]
+        }
+      })
+
+      mockConfig('watcher', {
+        enabled: false
+      })
+
+      mockConfig('webhooks', { enabled: true })
+
+      await new Peon().start()
+
+      assert.ok(handlers.push)
+      handlers.push('repo', 'data')
+
+      assert.deepEqual(dispatched, ['push', 'data'])
+    })
+
+    it('does not start webhook server when disabled', async function() {
+      let created
+      mock(
+        'WebhookServer',
+        class {
+          constructor() {
+            created = true
+          }
+        }
+      )
+
+      mockConfig('watcher', {
+        enabled: false
+      })
+
+      mockConfig('webhooks', { enabled: false })
+
+      await new Peon().start()
+
+      assert.notOk(created)
+    })
+  })
+})

--- a/test/unit/status/github.test.js
+++ b/test/unit/status/github.test.js
@@ -1,0 +1,111 @@
+const { assert } = require('chai')
+const { lookup, mock, mockConfig } = require('../../helpers')
+
+const { GithubStatus } = lookup()
+
+describe('unit | status/github', function() {
+  describe('GithubStatus.update', function() {
+    it('does nothing when no github token is configured', function() {
+      let runCalled = false
+
+      mockConfig('githubAPIToken', null)
+      mock(
+        'Queue',
+        class {
+          run() {
+            runCalled = true
+          }
+        }
+      )
+
+      new GithubStatus().update(
+        'git@github.com:org/repo',
+        'id',
+        'sha',
+        'state',
+        'description'
+      )
+
+      assert.notOk(runCalled)
+    })
+
+    it('does nothing for non-github repositories', function() {
+      let runCalled = false
+
+      mockConfig('githubAPIToken', 'abcdef')
+      mock(
+        'Queue',
+        class {
+          run() {
+            runCalled = true
+          }
+        }
+      )
+
+      new GithubStatus().update(
+        'git@example.com:org/repo',
+        'id',
+        'sha',
+        'state',
+        'description'
+      )
+
+      assert.notOk(runCalled)
+    })
+
+    it('enqueues and sends updates', function() {
+      let octokitParams, octokitStatus, queuedFunction
+
+      mockConfig('githubAPIToken', 'abcdef')
+      mockConfig('statusUrl', 'status://url')
+      mock(
+        'Octokit',
+        class {
+          constructor(params) {
+            octokitParams = params
+
+            this.repos = {
+              createStatus(status) {
+                octokitStatus = status
+                return Promise.resolve()
+              }
+            }
+          }
+        }
+      )
+      mock(
+        'Queue',
+        class {
+          run(fun) {
+            queuedFunction = fun
+          }
+        }
+      )
+
+      new GithubStatus().update(
+        'git@github.com:org/repo',
+        'REPOBUILDS#BUILDID',
+        'COMMITSHA',
+        'STATUSSTATE',
+        'STATUSDESCR'
+      )
+
+      assert.deepEqual(octokitParams, { auth: 'token abcdef' })
+      assert.equal(typeof queuedFunction, 'function')
+      assert.notOk(octokitStatus)
+
+      queuedFunction()
+
+      assert.deepEqual(octokitStatus, {
+        owner: 'org',
+        repo: 'repo',
+        sha: 'COMMITSHA',
+        state: 'STATUSSTATE',
+        // eslint-disable-next-line camelcase
+        target_url: 'status://url/REPOBUILDS/BUILDID.html',
+        context: 'peon',
+        description: 'STATUSDESCR'
+      })
+    })
+  })
+})

--- a/test/unit/status/render.test.js
+++ b/test/unit/status/render.test.js
@@ -1,0 +1,451 @@
+const { assert } = require('chai')
+const { mkdir, readFile, writeFile } = require('fs-extra')
+const { resolve } = require('path')
+const { lookup, mock, mockConfig, tempDir } = require('../../helpers')
+const { Renderer } = lookup()
+
+describe('unit | status/render', function() {
+  let workingDirectory
+
+  beforeEach(async function() {
+    workingDirectory = await tempDir()
+    mockConfig('workingDirectory', workingDirectory)
+  })
+
+  describe('Renderer.init', function() {
+    it('registers a date helper', async function() {
+      let helpers = {}
+      mock('Handlebars', {
+        compile() {},
+        registerHelper(name, helper) {
+          helpers[name] = helper
+        }
+      })
+
+      let renderer = new Renderer()
+      await renderer.init()
+
+      assert.isFunction(helpers.date)
+
+      let date = new Date('2001-02-03T04:05:06Z')
+      assert.equal(helpers.date(Number(date)), '2001-02-03T04:05:06.000Z')
+    })
+
+    it('compiles templates', async function() {
+      let renderer = new Renderer()
+      await renderer.init()
+
+      assert.isFunction(renderer.indexTemplate)
+      assert.isFunction(renderer.buildTemplate)
+    })
+  })
+
+  describe('Renderer._getLastRender', function() {
+    it('returns 0 when no previous render was done', async function() {
+      let renderer = new Renderer()
+      assert.equal(await renderer._getLastRender(), 0)
+      assert.equal(renderer.lastRender, 0)
+    })
+
+    it('returns last render date from saved JSON file', async function() {
+      let renderer = new Renderer()
+
+      await mkdir(resolve(workingDirectory, 'status'))
+      await writeFile(
+        resolve(workingDirectory, 'status', 'peon-status.json'),
+        JSON.stringify({ lastRender: 1234 })
+      )
+
+      assert.equal(await renderer._getLastRender(), 1234)
+      assert.equal(renderer.lastRender, 1234)
+    })
+
+    it('does not read JSON file again when last render is already known', async function() {
+      let renderer = new Renderer()
+
+      await mkdir(resolve(workingDirectory, 'status'))
+      await writeFile(
+        resolve(workingDirectory, 'status', 'peon-status.json'),
+        'invalid json'
+      )
+
+      renderer.lastRender = 1234
+      assert.equal(await renderer._getLastRender(), 1234)
+      assert.equal(renderer.lastRender, 1234)
+    })
+  })
+
+  describe('Renderer._setLastRender', function() {
+    it('sets last render property and saves to JSON file', async function() {
+      let renderer = new Renderer()
+      await renderer._setLastRender(1234)
+      assert.equal(renderer.lastRender, 1234)
+      assert.deepEqual(
+        JSON.parse(
+          await readFile(
+            resolve(workingDirectory, 'status', 'peon-status.json')
+          )
+        ),
+        { lastRender: 1234 }
+      )
+    })
+  })
+
+  describe('Renderer._readReposStatus', function() {
+    it('reads nothing when no status files are present', async function() {
+      assert.deepEqual(await new Renderer()._readReposStatus(), {})
+    })
+
+    it('ignores peon-status.json', async function() {
+      await mkdir(resolve(workingDirectory, 'status'))
+      await writeFile(
+        resolve(workingDirectory, 'status', 'peon-status.json'),
+        'invalid json'
+      )
+
+      assert.deepEqual(await new Renderer()._readReposStatus(), {})
+    })
+
+    it('reads data from repo status files', async function() {
+      await mkdir(resolve(workingDirectory, 'status'))
+      await writeFile(
+        resolve(workingDirectory, 'status', 'repo1.json'),
+        JSON.stringify({
+          data: { from: 'repo1' }
+        })
+      )
+      await writeFile(
+        resolve(workingDirectory, 'status', 'repo2.json'),
+        JSON.stringify({
+          data: { from: 'repo2' }
+        })
+      )
+
+      assert.deepEqual(await new Renderer()._readReposStatus(), {
+        repo1: { data: { from: 'repo1' } },
+        repo2: { data: { from: 'repo2' } }
+      })
+    })
+  })
+
+  describe('Renderer._renderBuild', function() {
+    let statusDirectory
+
+    beforeEach(async function() {
+      statusDirectory = await tempDir()
+      mockConfig('statusDirectory', statusDirectory)
+    })
+
+    it('does not render a build when not updated since last render', async function() {
+      let renderer = new Renderer()
+      renderer.lastRender = 1234
+      renderer.buildTemplate = function() {
+        throw new Error('should not be called')
+      }
+
+      await renderer._renderBuild('repo#100', { updated: 1000 })
+      assert.ok(true)
+    })
+
+    it('renders build when updated since last render', async function() {
+      let renderer = new Renderer()
+      let templateData
+      renderer.lastRender = 1234
+      renderer.buildTemplate = function(data) {
+        templateData = data
+        return 'template render output'
+      }
+
+      await renderer._renderBuild('repo#100', {
+        updated: 2000,
+        data: 'some build data'
+      })
+
+      assert.deepEqual(templateData, {
+        buildId: 'repo#100',
+        updated: 2000,
+        data: 'some build data',
+        isRunning: false
+      })
+
+      assert.equal(
+        await readFile(resolve(statusDirectory, 'repo', '100.html')),
+        'template render output'
+      )
+    })
+
+    it('passes isRunning=true when build is pending', async function() {
+      let renderer = new Renderer()
+      let templateData
+      renderer.lastRender = 1234
+      renderer.buildTemplate = function(data) {
+        templateData = data
+      }
+
+      await renderer._renderBuild('repo#100', {
+        updated: 2000,
+        data: 'some build data',
+        status: 'pending'
+      })
+
+      assert.ok(templateData.isRunning)
+    })
+
+    it('passes isRunning=true when build is running', async function() {
+      let renderer = new Renderer()
+      let templateData
+      renderer.lastRender = 1234
+      renderer.buildTemplate = function(data) {
+        templateData = data
+      }
+
+      await renderer._renderBuild('repo#100', {
+        updated: 2000,
+        data: 'some build data',
+        status: 'running'
+      })
+
+      assert.ok(templateData.isRunning)
+    })
+
+    it('passes isRunning=false when build is successful', async function() {
+      let renderer = new Renderer()
+      let templateData
+      renderer.lastRender = 1234
+      renderer.buildTemplate = function(data) {
+        templateData = data
+      }
+
+      await renderer._renderBuild('repo#100', {
+        updated: 2000,
+        data: 'some build data',
+        status: 'success'
+      })
+
+      assert.notOk(templateData.isRunning)
+    })
+
+    it('passes isRunning=false when build is failed', async function() {
+      let renderer = new Renderer()
+      let templateData
+      renderer.lastRender = 1234
+      renderer.buildTemplate = function(data) {
+        templateData = data
+      }
+
+      await renderer._renderBuild('repo#100', {
+        updated: 2000,
+        data: 'some build data',
+        status: 'failed'
+      })
+
+      assert.notOk(templateData.isRunning)
+    })
+
+    it('passes isRunning=false when build is cancelled', async function() {
+      let renderer = new Renderer()
+      let templateData
+      renderer.lastRender = 1234
+      renderer.buildTemplate = function(data) {
+        templateData = data
+      }
+
+      await renderer._renderBuild('repo#100', {
+        updated: 2000,
+        data: 'some build data',
+        status: 'cancelled'
+      })
+
+      assert.notOk(templateData.isRunning)
+    })
+  })
+
+  describe('Renderer._renderRepo', function() {
+    it('calls _renderBuild for each build', async function() {
+      let log = []
+      let renderer = new Renderer()
+      renderer._renderBuild = function() {
+        log.push([...arguments])
+      }
+
+      await renderer._renderRepo({
+        builds: {
+          'repo#1': { data: 'build 1 data' },
+          'repo#2': { data: 'build 2 data' }
+        }
+      })
+
+      assert.deepEqual(log, [
+        ['repo#1', { data: 'build 1 data' }],
+        ['repo#2', { data: 'build 2 data' }]
+      ])
+    })
+  })
+
+  describe('Renderer._renderIndex', function() {
+    let statusDirectory
+
+    beforeEach(async function() {
+      statusDirectory = await tempDir()
+      mockConfig('statusDirectory', statusDirectory)
+    })
+
+    it('renders index', async function() {
+      let renderer = new Renderer()
+      renderer.indexTemplate = function() {
+        return 'rendered template data'
+      }
+
+      await renderer._renderIndex(1, {})
+
+      assert.equal(
+        await readFile(resolve(statusDirectory, 'index.html')),
+        'rendered template data'
+      )
+    })
+
+    it('passes hasData=false when no repository data is available', async function() {
+      let renderer = new Renderer()
+      let templateData
+      renderer.indexTemplate = function(data) {
+        templateData = data
+      }
+
+      await renderer._renderIndex(1, {})
+
+      assert.notOk(templateData.hasData)
+    })
+
+    it('passes hasData=true when repository data is available', async function() {
+      let renderer = new Renderer()
+      let templateData
+      renderer.indexTemplate = function(data) {
+        templateData = data
+      }
+
+      await renderer._renderIndex(1, { repo: { builds: {} } })
+
+      assert.ok(templateData.hasData)
+    })
+
+    it('passes render date', async function() {
+      let renderer = new Renderer()
+      let templateData
+      renderer.indexTemplate = function(data) {
+        templateData = data
+      }
+
+      await renderer._renderIndex(1234, { repo: { builds: {} } })
+
+      assert.equal(templateData.now, 1234)
+    })
+
+    it('passes last 5 builds for each repository', async function() {
+      let renderer = new Renderer()
+      let templateData
+      renderer.indexTemplate = function(data) {
+        templateData = data
+      }
+
+      await renderer._renderIndex(1, {
+        repoA: {
+          builds: {
+            'repoA#1': { status: 'success' },
+            'repoA#2': { status: 'success' },
+            'repoA#3': { status: 'success' },
+            'repoA#4': { status: 'failed' },
+            'repoA#5': { status: 'success' },
+            'repoA#6': { status: 'cancelled' },
+            'repoA#7': { status: 'success' },
+            'repoA#8': { status: 'failed' },
+            'repoA#9': { status: 'success' },
+            'repoA#10': { status: 'success' },
+            'repoA#11': { status: 'success' }
+          }
+        },
+        repoB: {
+          builds: {
+            'repoB#1': { status: 'failed' }
+          }
+        }
+      })
+
+      assert.deepEqual(templateData.repos.repoA.lastBuilds, [
+        { buildId: 'repoA#11', link: 'repoA/11.html', status: 'success' },
+        { buildId: 'repoA#10', link: 'repoA/10.html', status: 'success' },
+        { buildId: 'repoA#9', link: 'repoA/9.html', status: 'success' },
+        { buildId: 'repoA#8', link: 'repoA/8.html', status: 'failed' },
+        { buildId: 'repoA#7', link: 'repoA/7.html', status: 'success' }
+      ])
+
+      assert.deepEqual(templateData.repos.repoB.lastBuilds, [
+        { buildId: 'repoB#1', link: 'repoB/1.html', status: 'failed' }
+      ])
+    })
+
+    it('passes last successful build for each ref for each repo, sorting refs by name, master first', async function() {
+      let renderer = new Renderer()
+      let templateData
+      renderer.indexTemplate = function(data) {
+        templateData = data
+      }
+
+      await renderer._renderIndex(1, {
+        repoA: {
+          builds: {
+            'repoA#1': { id: 1, status: 'success', branch: 'master' },
+            'repoA#2': { id: 2, status: 'success', tag: 'mytag' },
+            'repoA#3': { id: 3, status: 'success', branch: 'abranch' },
+            'repoA#4': { id: 4, status: 'failed', branch: 'master' },
+            'repoA#5': { id: 5, status: 'success', tag: 'atag' },
+            'repoA#6': { id: 6, status: 'cancelled', tag: 'atag' },
+            'repoA#7': { id: 7, status: 'success', branch: 'mybranch' },
+            'repoA#8': { id: 8, status: 'failed', branch: 'master' },
+            'repoA#9': { id: 9, status: 'success', branch: 'mybranch' },
+            'repoA#10': { id: 10, status: 'success', tag: 'atag' },
+            'repoA#11': { id: 11, status: 'success', tag: 'mytag' }
+          }
+        }
+      })
+
+      assert.deepEqual(
+        templateData.repos.repoA.lastSuccessfulBuildByRef.map((b) => b.id),
+        [1, 3, 10, 9, 11]
+      )
+    })
+  })
+
+  describe('Renderer.render', function() {
+    it('loads repo status, renders builds, renders index and updates last render', async function() {
+      let log = []
+      let renderer = new Renderer()
+
+      renderer._readReposStatus = async function() {
+        log.push('read status')
+        return { repo1: 'repo 1 data', repo2: 'repo 2 data' }
+      }
+      renderer._renderRepo = async function(status) {
+        log.push(`render with ${status}`)
+      }
+      renderer._renderIndex = async function(now, status) {
+        assert.equal(now, 1234)
+        assert.deepEqual(status, { repo1: 'repo 1 data', repo2: 'repo 2 data' })
+        log.push('render index')
+      }
+      renderer._setLastRender = async function(now) {
+        assert.equal(now, 1234)
+        log.push('set last render')
+      }
+
+      await renderer.render(1234)
+
+      assert.deepEqual(log, [
+        'read status',
+        'render with repo 1 data',
+        'render with repo 2 data',
+        'render index',
+        'set last render'
+      ])
+    })
+  })
+})

--- a/test/unit/status/status.test.js
+++ b/test/unit/status/status.test.js
@@ -1,0 +1,534 @@
+const { assert } = require('chai')
+const { readFile, writeFile } = require('fs-extra')
+const { resolve } = require('path')
+const { lookup, mock, mockConfig, tempDir } = require('../../helpers')
+const { Status } = lookup()
+
+describe('unit | status/status', function() {
+  let statusRoot
+
+  beforeEach(async function() {
+    let wd = await tempDir()
+    statusRoot = resolve(wd, 'status')
+    mockConfig('workingDirectory', wd)
+    mockConfig('statusDirectory', await tempDir())
+  })
+
+  describe('Status._updateRepoStatus', function() {
+    it('initializes repo status file', async function() {
+      mock('renderer', { render() {} })
+
+      await new Status()._updateRepoStatus('reponame', (s) => s)
+
+      let status = JSON.parse(
+        await readFile(resolve(statusRoot, 'reponame.json'))
+      )
+      assert.deepEqual(status, {
+        nextBuildNum: 1,
+        builds: {}
+      })
+    })
+
+    it('passes current status file content and current date to updater', async function() {
+      mock('renderer', { render() {} })
+
+      let status = new Status()
+
+      await status._ensureDirsExist()
+      await writeFile(
+        resolve(statusRoot, 'reponame.json'),
+        JSON.stringify({ some: { status: 'content' } })
+      )
+
+      let updaterArgs
+      await status._updateRepoStatus('reponame', function() {
+        updaterArgs = [...arguments]
+      })
+
+      assert.deepEqual(updaterArgs[0], { some: { status: 'content' } })
+      assert.closeTo(updaterArgs[1], Date.now(), 1000)
+    })
+
+    it('writes updated status to status file', async function() {
+      mock('renderer', { render() {} })
+
+      await new Status()._updateRepoStatus(
+        'reponame',
+        (s) => (s.some = { status: 'content' })
+      )
+
+      let status = JSON.parse(
+        await readFile(resolve(statusRoot, 'reponame.json'))
+      )
+      assert.deepEqual(status.some, { status: 'content' })
+    })
+
+    it('returns what updater returns', async function() {
+      mock('renderer', { render() {} })
+
+      assert.equal(
+        await new Status()._updateRepoStatus('reponame', () => 'foo'),
+        'foo'
+      )
+    })
+
+    it('calls renderer.render with current date', async function() {
+      let called
+      mock('renderer', {
+        render(now) {
+          called = now
+        }
+      })
+
+      await new Status()._updateRepoStatus('reponame', () => {})
+
+      assert.closeTo(called, Date.now(), 1000)
+    })
+  })
+
+  describe('Status.startBuild', function() {
+    it('generates a new build ID', async function() {
+      let status = new Status()
+      let updateArgs
+      status._updateRepoStatus = function() {
+        updateArgs = [...arguments]
+        return 'ret'
+      }
+
+      let ret = await status.startBuild('repo/url', 'reponame')
+      assert.equal(ret, 'ret')
+      assert.equal(updateArgs[0], 'reponame')
+
+      let repoStatus = { nextBuildNum: 100, builds: {} }
+      assert.equal(updateArgs[1](repoStatus), 'reponame#100')
+      assert.equal(repoStatus.nextBuildNum, 101)
+    })
+
+    it('sends a "pending" github status update', async function() {
+      let updater, ghArgs
+
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      mock('githubStatus', {
+        update() {
+          ghArgs = [...arguments]
+        }
+      })
+
+      await status.startBuild('repo/url', 'reponame', '', '', 'sha')
+
+      updater({ nextBuildNum: 100, builds: {} })
+
+      assert.deepEqual(ghArgs, [
+        'repo/url',
+        'reponame#100',
+        'sha',
+        'pending',
+        'Peon build is queued'
+      ])
+    })
+
+    it('adds info for the new build to the repo status', async function() {
+      let updater
+
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      await status.startBuild(
+        'repo/url',
+        'reponame',
+        'branch',
+        'mybranch',
+        'sha'
+      )
+
+      let repoStatus = { nextBuildNum: 100, builds: {} }
+      let now = Date.now()
+      updater(repoStatus, now)
+      assert.deepEqual(repoStatus.builds['reponame#100'], {
+        branch: 'mybranch',
+        tag: null,
+        sha: 'sha',
+        url: 'repo/url',
+        enqueued: now,
+        updated: now,
+        status: 'pending',
+        steps: []
+      })
+
+      await status.startBuild('repo/url', 'reponame', 'tag', 'mytag', 'sha')
+
+      repoStatus = { nextBuildNum: 100, builds: {} }
+      updater(repoStatus, now)
+      assert.deepEqual(repoStatus.builds['reponame#100'], {
+        branch: null,
+        tag: 'mytag',
+        sha: 'sha',
+        url: 'repo/url',
+        enqueued: now,
+        updated: now,
+        status: 'pending',
+        steps: []
+      })
+    })
+  })
+
+  describe('Status.updateBuildStep', async function() {
+    it('sends a "pending" github status update with current step', async function() {
+      let updater, ghArgs
+
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      mock('githubStatus', {
+        update() {
+          ghArgs = [...arguments]
+        }
+      })
+
+      await status.updateBuildStep('reponame#100', 'my step')
+
+      updater({
+        nextBuildNum: 100,
+        builds: { 'reponame#100': { url: 'repo/url', sha: 'sha', steps: [] } }
+      })
+
+      assert.deepEqual(ghArgs, [
+        'repo/url',
+        'reponame#100',
+        'sha',
+        'pending',
+        "Peon build is running 'my step'"
+      ])
+    })
+
+    it('updates build status, update date and start date', async function() {
+      let updater
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      await status.updateBuildStep('reponame#100', 'my step')
+
+      let now = Date.now()
+      let before = now - 1000
+      let build = {
+        url: 'repo/url',
+        steps: [],
+        updated: before,
+        status: 'pending'
+      }
+      let repoStatus = {
+        nextBuildNum: 100,
+        builds: { 'reponame#100': build }
+      }
+      updater(repoStatus, now)
+
+      assert.equal(build.status, 'running')
+      assert.equal(build.updated, now)
+      assert.equal(build.start, now)
+    })
+
+    it('does not update start date when it is already present', async function() {
+      let updater
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      await status.updateBuildStep('reponame#100', 'my step')
+
+      let now = Date.now()
+      let before = now - 1000
+      let build = {
+        url: 'repo/url',
+        steps: [],
+        start: before
+      }
+      let repoStatus = {
+        nextBuildNum: 100,
+        builds: { 'reponame#100': build }
+      }
+
+      updater(repoStatus, now)
+
+      assert.equal(build.start, before)
+    })
+
+    it('adds a new step when the step is not present', async function() {
+      let updater
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      await status.updateBuildStep(
+        'reponame#100',
+        'my step',
+        'some status',
+        'some output'
+      )
+
+      let now = Date.now()
+      let before = now - 1000
+      let build = {
+        url: 'repo/url',
+        steps: [],
+        start: before
+      }
+      let repoStatus = {
+        nextBuildNum: 100,
+        builds: { 'reponame#100': build }
+      }
+      updater(repoStatus, now)
+
+      assert.deepEqual(build.steps, [
+        {
+          description: 'my step',
+          start: now,
+          status: 'some status',
+          output: 'some output'
+        }
+      ])
+    })
+
+    it('updates an existing step', async function() {
+      let updater
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      await status.updateBuildStep(
+        'reponame#100',
+        'my step',
+        'some new status',
+        'some new output'
+      )
+
+      let now = Date.now()
+      let before = now - 1000
+      let build = {
+        url: 'repo/url',
+        steps: [
+          {
+            description: 'my step',
+            start: before,
+            status: 'some status',
+            output: 'some output'
+          }
+        ],
+        start: before
+      }
+      let repoStatus = {
+        nextBuildNum: 100,
+        builds: { 'reponame#100': build }
+      }
+      updater(repoStatus, now)
+
+      assert.deepEqual(build.steps, [
+        {
+          description: 'my step',
+          start: before,
+          status: 'some new status',
+          output: 'some new output'
+        }
+      ])
+    })
+
+    it('sets step end and duration when step status is "success"', async function() {
+      let updater
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      await status.updateBuildStep(
+        'reponame#100',
+        'my step',
+        'success',
+        'some new output'
+      )
+
+      let now = Date.now()
+      let before = now - 1000
+      let build = {
+        url: 'repo/url',
+        steps: [
+          {
+            description: 'my step',
+            start: before,
+            status: 'some status',
+            output: 'some output'
+          }
+        ],
+        start: before
+      }
+      let repoStatus = {
+        nextBuildNum: 100,
+        builds: { 'reponame#100': build }
+      }
+      updater(repoStatus, now)
+
+      assert.deepEqual(build.steps, [
+        {
+          description: 'my step',
+          start: before,
+          end: now,
+          duration: 1000,
+          status: 'success',
+          output: 'some new output'
+        }
+      ])
+    })
+
+    it('sets step end and duration when step status is "failed"', async function() {
+      let updater
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      await status.updateBuildStep(
+        'reponame#100',
+        'my step',
+        'failed',
+        'some new output'
+      )
+
+      let now = Date.now()
+      let before = now - 1000
+      let build = {
+        url: 'repo/url',
+        steps: [
+          {
+            description: 'my step',
+            start: before,
+            status: 'some status',
+            output: 'some output'
+          }
+        ],
+        start: before
+      }
+      let repoStatus = {
+        nextBuildNum: 100,
+        builds: { 'reponame#100': build }
+      }
+      updater(repoStatus, now)
+
+      assert.deepEqual(build.steps, [
+        {
+          description: 'my step',
+          start: before,
+          end: now,
+          duration: 1000,
+          status: 'failed',
+          output: 'some new output'
+        }
+      ])
+    })
+  })
+
+  describe('Status.finishBuild', function() {
+    it('sends a "success" github status update when build status is successful', async function() {
+      let updater, ghArgs
+
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      mock('githubStatus', {
+        update() {
+          ghArgs = [...arguments]
+        }
+      })
+
+      await status.finishBuild('reponame#100', 'success')
+
+      updater({
+        nextBuildNum: 100,
+        builds: { 'reponame#100': { url: 'repo/url', sha: 'sha', steps: [] } }
+      })
+
+      assert.deepEqual(ghArgs, [
+        'repo/url',
+        'reponame#100',
+        'sha',
+        'success',
+        'Peon build is finished'
+      ])
+    })
+
+    it('sends a "failed" github status update when build status is failed', async function() {
+      let updater, ghArgs
+
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      mock('githubStatus', {
+        update() {
+          ghArgs = [...arguments]
+        }
+      })
+
+      await status.finishBuild('reponame#100', 'failed')
+
+      updater({
+        nextBuildNum: 100,
+        builds: { 'reponame#100': { url: 'repo/url', sha: 'sha', steps: [] } }
+      })
+
+      assert.deepEqual(ghArgs, [
+        'repo/url',
+        'reponame#100',
+        'sha',
+        'failed',
+        'Peon build has failed'
+      ])
+    })
+
+    it('sends a "failed" github status update when build status is cancelled', async function() {
+      let updater, ghArgs
+
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      mock('githubStatus', {
+        update() {
+          ghArgs = [...arguments]
+        }
+      })
+
+      await status.finishBuild('reponame#100', 'cancelled')
+
+      updater({
+        nextBuildNum: 100,
+        builds: { 'reponame#100': { url: 'repo/url', sha: 'sha', steps: [] } }
+      })
+
+      assert.deepEqual(ghArgs, [
+        'repo/url',
+        'reponame#100',
+        'sha',
+        'failed',
+        'Peon build was cancelled'
+      ])
+    })
+
+    it('updates build status', async function() {
+      let updater
+
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      await status.finishBuild('reponame#100', 'some status', 'some extra info')
+
+      let now = Date.now()
+      let before = now - 1000
+      let build = { url: 'repo/url', sha: 'sha', steps: [], start: before }
+
+      updater(
+        {
+          nextBuildNum: 100,
+          builds: { 'reponame#100': build }
+        },
+        now
+      )
+
+      assert.equal(build.status, 'some status')
+      assert.equal(build.end, now)
+      assert.equal(build.updated, now)
+      assert.equal(build.duration, 1000)
+      assert.equal(build.extra, 'some extra info')
+    })
+  })
+})

--- a/test/unit/utils/environment.test.js
+++ b/test/unit/utils/environment.test.js
@@ -1,0 +1,78 @@
+const { assert } = require('chai')
+const { lookup } = require('../../helpers')
+
+const { Environment } = lookup()
+
+describe('unit | utils/environment', function() {
+  describe('Environment.evaluate', function() {
+    it('returns values passed to ctor', function() {
+      assert.equal(new Environment({ foo: 'bar' }).evaluate('$foo'), 'bar')
+    })
+
+    it('returns empty values for unknown variables', function() {
+      assert.equal(new Environment({}).evaluate('$foo'), '')
+    })
+
+    it('matches variables on word boundaries', function() {
+      assert.equal(
+        new Environment({ foo: 'bar' }).evaluate('ab$foo/$fooo'),
+        'abbar/'
+      )
+    })
+
+    it('evaluates recursively', function() {
+      assert.equal(
+        new Environment({
+          foo: '$bar',
+          bar: '$baz',
+          baz: 'bing'
+        }).evaluate('$foo'),
+        'bing'
+      )
+    })
+
+    it('throws on evaluation loop', function() {
+      assert.throws(
+        () =>
+          new Environment({
+            foo: '$bar',
+            bar: '$baz',
+            baz: '$foo'
+          }).evaluate('$foo'),
+        'Evaluation loop: foo => bar => baz => foo'
+      )
+    })
+  })
+
+  describe('Environment.evaluateAll', function() {
+    it('returns all env', function() {
+      assert.deepEqual(
+        new Environment({ foo: 'bar', baz: 'bing' }).evaluateAll(),
+        { foo: 'bar', baz: 'bing' }
+      )
+    })
+
+    it('evaluates variables', function() {
+      assert.deepEqual(
+        new Environment({
+          foo: 'bar',
+          baz: 'bing',
+          var1: '$foo/$baz'
+        }).evaluateAll(),
+        { foo: 'bar', baz: 'bing', var1: 'bar/bing' }
+      )
+    })
+
+    it('throws on evaluation loop', function() {
+      assert.throws(
+        () =>
+          new Environment({
+            foo: '$bar',
+            bar: '$foo',
+            var1: '$foo/$baz'
+          }).evaluateAll(),
+        'Evaluation loop'
+      )
+    })
+  })
+})

--- a/test/unit/utils/misc.test.js
+++ b/test/unit/utils/misc.test.js
@@ -1,0 +1,122 @@
+const { assert } = require('chai')
+const { lookup, mock, mockConfig } = require('../../helpers')
+
+let {
+  gitFetchOpts,
+  misc: { extractRepoName, extractGithubRepo }
+} = lookup()
+
+describe('unit | utils/misc', function() {
+  describe('extractRepoName', function() {
+    it('extracts from http(s) urls', function() {
+      assert.equal(extractRepoName('http://github.com/org/repo'), 'repo')
+      assert.equal(extractRepoName('http://github.com/org/repo.git'), 'repo')
+      assert.equal(extractRepoName('https://github.com/org/repo'), 'repo')
+      assert.equal(extractRepoName('https://github.com/org/repo.git'), 'repo')
+    })
+
+    it('extracts from ssh urls', function() {
+      assert.equal(extractRepoName('git@github.com:org/repo'), 'repo')
+      assert.equal(extractRepoName('git@github.com:org/repo.git'), 'repo')
+    })
+
+    it('extracts from git urls', function() {
+      assert.equal(extractRepoName('git://github.com/org/repo'), 'repo')
+      assert.equal(extractRepoName('git://github.com/org/repo.git'), 'repo')
+      assert.equal(extractRepoName('git+ssh://github.com/org/repo'), 'repo')
+      assert.equal(extractRepoName('git+ssh://github.com/org/repo.git'), 'repo')
+    })
+  })
+
+  describe('extractGithubRepo', function() {
+    it('extracts github repository info', function() {
+      assert.deepEqual(extractGithubRepo('https://github.com/org/repo'), {
+        org: 'org',
+        repo: 'repo'
+      })
+      assert.deepEqual(extractGithubRepo('https://github.com/org/repo.git'), {
+        org: 'org',
+        repo: 'repo'
+      })
+      assert.deepEqual(extractGithubRepo('git://github.com/org/repo'), {
+        org: 'org',
+        repo: 'repo'
+      })
+      assert.deepEqual(extractGithubRepo('git://github.com/org/repo.git'), {
+        org: 'org',
+        repo: 'repo'
+      })
+      assert.deepEqual(extractGithubRepo('git@github.com:org/repo'), {
+        org: 'org',
+        repo: 'repo'
+      })
+      assert.deepEqual(extractGithubRepo('git@github.com:org/repo.git'), {
+        org: 'org',
+        repo: 'repo'
+      })
+    })
+
+    it('does not extract from non-github urls', function() {
+      assert.equal(extractGithubRepo('https://example.com/org/repo'), undefined)
+      assert.equal(extractGithubRepo('git@example.com:org/repo'), undefined)
+    })
+  })
+
+  describe('gitFetchOpts', function() {
+    it('returns key based credentials', function() {
+      let {
+        callbacks: { credentials }
+      } = gitFetchOpts
+
+      mockConfig('git', {
+        authMethod: 'key',
+        privateKey: 'path/to/id_rsa',
+        publicKey: 'path/to/id_rsa.pub',
+        keyPassword: 'wowsupersecret'
+      })
+
+      let called = false
+
+      mock('Git', {
+        Cred: {
+          sshKeyNew(username, pubkey, privkey, pass) {
+            called = true
+            assert.equal(username, 'johndoe')
+            assert.equal(pubkey, 'path/to/id_rsa.pub')
+            assert.equal(privkey, 'path/to/id_rsa')
+            assert.equal(pass, 'wowsupersecret')
+          }
+        }
+      })
+
+      credentials('url', 'johndoe')
+
+      assert.ok(called)
+    })
+
+    it('returns agent based credentials', function() {
+      let {
+        callbacks: { credentials }
+      } = gitFetchOpts
+
+      mockConfig('git', {
+        authMethod: 'agent'
+      })
+
+      let called = false
+
+      mock('Git', {
+        Cred: {
+          sshKeyFromAgent(username) {
+            called = true
+            assert.equal(username, 'johndoe')
+          }
+        }
+      })
+
+      credentials('url', 'johndoe')
+
+      assert.ok(called)
+    })
+  })
+})

--- a/test/unit/utils/queue.test.js
+++ b/test/unit/utils/queue.test.js
@@ -1,0 +1,41 @@
+const { assert } = require('chai')
+const { lookup, wait } = require('../../helpers')
+
+const { Queue } = lookup()
+
+describe('unit | utils/queue', function() {
+  describe('Queue', function() {
+    it('runs async tasks in queue order', async function() {
+      this.slow(300)
+
+      let log = []
+
+      function makeTask(id, waitStart) {
+        return async function() {
+          if (waitStart) {
+            await wait(50)
+          }
+
+          log.push(`starting task ${id}`)
+          await wait(50)
+          log.push(`finishing task ${id}`)
+        }
+      }
+
+      let q = new Queue()
+      q.run(makeTask(1, true))
+      q.run(makeTask(2))
+      q.run(makeTask(3))
+      await q.join()
+
+      assert.deepEqual(log, [
+        'starting task 1',
+        'finishing task 1',
+        'starting task 2',
+        'finishing task 2',
+        'starting task 3',
+        'finishing task 3'
+      ])
+    })
+  })
+})

--- a/test/unit/watch/watcher.test.js
+++ b/test/unit/watch/watcher.test.js
@@ -1,0 +1,177 @@
+const { assert } = require('chai')
+const { lookup, mock, mockConfig, tempDir, wait } = require('../../helpers')
+
+const { Watcher } = lookup()
+
+describe('unit | watch/watcher', function() {
+  let workingDirectory
+
+  beforeEach(async function() {
+    workingDirectory = await tempDir()
+    mockConfig('workingDirectory', workingDirectory)
+  })
+
+  describe('Watcher._openRepository', function() {
+    it('opens repository when it already exists', async function() {
+      let openPath
+      let repo = {}
+      mock('Git', {
+        Repository: {
+          open(path) {
+            openPath = path
+            return repo
+          }
+        }
+      })
+
+      let ret = await new Watcher('reponame', 'repourl', [])._openRepository()
+
+      assert.equal(openPath, `${workingDirectory}/repos/reponame`)
+      assert.equal(ret.repo, repo)
+      assert.notOk(ret.cloned)
+    })
+
+    it('clones repository when it does not exist', async function() {
+      let clonePath, cloneUrl
+      let repo = {}
+      mock('Git', {
+        Repository: {
+          open() {
+            throw new Error()
+          }
+        },
+        Clone(url, path) {
+          cloneUrl = url
+          clonePath = path
+          return repo
+        }
+      })
+
+      let ret = await new Watcher('reponame', 'repourl', [])._openRepository()
+
+      assert.equal(clonePath, `${workingDirectory}/repos/reponame`)
+      assert.equal(cloneUrl, 'repourl')
+      assert.equal(ret.repo, repo)
+      assert.ok(ret.cloned)
+    })
+  })
+
+  describe('Watcher._getCurrentSHAs', function() {
+    it('returns no current SHAs when repository was just cloned', async function() {
+      let repo = {}
+
+      assert.deepEqual(
+        await new Watcher('reponame', 'repourl', [
+          'branch1',
+          'branch2'
+        ])._getCurrentSHAs(repo, true),
+        {}
+      )
+    })
+
+    it('returns current SHAs for each branch when repository was not just cloned', async function() {
+      let repo = {
+        getBranchCommit(branch) {
+          return {
+            sha() {
+              return `${branch}-SHA`
+            }
+          }
+        }
+      }
+
+      assert.deepEqual(
+        await new Watcher('reponame', 'repourl', [
+          'branch1',
+          'branch2'
+        ])._getCurrentSHAs(repo, false),
+        { branch1: 'origin/branch1-SHA', branch2: 'origin/branch2-SHA' }
+      )
+    })
+  })
+
+  describe('Watcher._checkUpdates', function() {
+    it('fetches origin when repository was not just cloned', async function() {
+      let fetchOrigin
+      let repo = {
+        async fetch(origin) {
+          fetchOrigin = origin
+        }
+      }
+
+      await new Watcher('reponame', 'repourl', [])._checkUpdates(
+        repo,
+        false,
+        {}
+      )
+      assert.equal(fetchOrigin, 'origin')
+    })
+
+    it('does not fetch when repository was just cloned', async function() {
+      let fetchCalled = false
+      let repo = {
+        async fetch() {
+          fetchCalled = true
+        }
+      }
+
+      await new Watcher('reponame', 'repourl', [])._checkUpdates(repo, true, {})
+      assert.notOk(fetchCalled)
+    })
+
+    it('compares SHAs and emits change events', async function() {
+      let events = []
+      let repo = {
+        getBranchCommit(branch) {
+          return {
+            sha() {
+              return `${branch}-SHA`
+            }
+          }
+        }
+      }
+
+      let watcher = new Watcher('reponame', 'repourl', [
+        'branch1',
+        'branch2',
+        'branch3'
+      ])
+
+      watcher.on('change', (ref, sha) => events.push({ ref, sha }))
+
+      await watcher._checkUpdates(repo, true, {
+        branch1: 'origin/branch1-SHA',
+        branch2: 'origin/branch2-differentSHA'
+      })
+
+      // branch1 has not changed
+      // branch2 has changed
+      // branch3 is new
+      assert.deepEqual(events, [
+        { ref: 'refs/heads/branch2', sha: 'origin/branch2-SHA' },
+        { ref: 'refs/heads/branch3', sha: 'origin/branch3-SHA' }
+      ])
+    })
+  })
+
+  describe('Watcher.start/stop', function() {
+    it('runs _check at regular intervals between start/stop calls', async function() {
+      this.slow(300)
+
+      let checkCalls = 0
+
+      mockConfig('watcher', { interval: 10 })
+      let watcher = new Watcher('reponame', 'repourl', [])
+      watcher._check = async() => checkCalls++
+
+      watcher.start()
+      await wait(100)
+      watcher.stop()
+      assert.ok(checkCalls > 0)
+      let stoppedAt = checkCalls
+
+      await wait(100)
+      assert.equal(checkCalls, stoppedAt)
+    })
+  })
+})

--- a/test/unit/watch/webhooks.test.js
+++ b/test/unit/watch/webhooks.test.js
@@ -1,0 +1,121 @@
+/* eslint-disable camelcase */
+
+const { assert } = require('chai')
+const crypto = require('crypto')
+const request = require('request-promise-native')
+const { lookup, mockConfig } = require('../../helpers')
+
+const { WebhookServer } = lookup()
+
+describe('unit | watch/webhooks', function() {
+  let server
+
+  afterEach(async function() {
+    if (server) {
+      await server.stop()
+    }
+  })
+
+  it('starts listening', async function() {
+    this.slow(300)
+
+    mockConfig('webhooks', { port: 9999 })
+    server = new WebhookServer()
+    await server.start()
+
+    try {
+      await request.get('http://localhost:9999/webhooks')
+      assert.ok(false)
+    } catch(e) {
+      assert.equal(e.statusCode, 404)
+    }
+  })
+
+  it('stops listening', async function() {
+    mockConfig('webhooks', { port: 9999 })
+    server = new WebhookServer()
+    await server.start()
+    await server.stop()
+    server = null
+
+    try {
+      await request.get('http://localhost:9999/webhooks')
+      assert.ok(false)
+    } catch(e) {
+      assert.equal(e.error.code, 'ECONNREFUSED')
+    }
+  })
+
+  it('fails on invalid secret signature', async function() {
+    mockConfig('webhooks', { port: 9999, secret: 'super-secret' })
+    server = new WebhookServer()
+    await server.start()
+
+    let payload = {
+      ref: 'refs/heads/mybranch',
+      head_commit: { id: 'shashasha' },
+      repository: {
+        name: 'myrepo',
+        ssh_url: 'git@example.com:org/myrepo'
+      }
+    }
+    let body = JSON.stringify(payload)
+
+    try {
+      await request.post({
+        url: 'http://localhost:9999/webhooks',
+        headers: {
+          'Content-type': 'application/json',
+          'X-GitHub-Delivery': crypto.createHmac('sha1', body).digest('hex'),
+          'X-GitHub-Event': 'push',
+          'X-Hub-Signature': `sha1=${crypto
+            .createHmac('sha1', 'wrong-secret')
+            .update(body)
+            .digest('hex')}`
+        },
+        body
+      })
+      assert.ok(false)
+    } catch(e) {
+      assert.equal(e.statusCode, 400)
+    }
+  })
+
+  it('emits push events', async function() {
+    let events = []
+
+    mockConfig('webhooks', { port: 9999, secret: 'super-secret' })
+    server = new WebhookServer()
+    server.on('push', (repo, data) => events.push({ repo, data }))
+
+    await server.start()
+
+    let payload = {
+      ref: 'refs/heads/mybranch',
+      head_commit: { id: 'shashasha' },
+      repository: {
+        name: 'myrepo',
+        ssh_url: 'git@example.com:org/myrepo'
+      }
+    }
+    let body = JSON.stringify(payload)
+
+    let response = await request.post({
+      url: 'http://localhost:9999/webhooks',
+      headers: {
+        'Content-type': 'application/json',
+        'X-GitHub-Delivery': crypto.createHmac('sha1', body).digest('hex'),
+        'X-GitHub-Event': 'push',
+        'X-Hub-Signature': `sha1=${crypto
+          .createHmac('sha1', 'super-secret')
+          .update(body)
+          .digest('hex')}`
+      },
+      body,
+      resolveWithFullResponse: true
+    })
+
+    assert.equal(response.statusCode, 200)
+    assert.deepEqual(events, [{ repo: 'myrepo', data: payload }])
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,6 +94,11 @@ ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ansi-colors@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
+  integrity sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
+
 ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
@@ -141,10 +146,30 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+  integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
+
+arr-flatten@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+  integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
+
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+  integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+  integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -168,6 +193,16 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+  integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
 async@^2.5.0, async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
@@ -179,6 +214,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
+atob@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -211,6 +251,19 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  integrity sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -268,6 +321,27 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+braces@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+  integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
+
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+  integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
+
 btoa-lite@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
@@ -306,6 +380,21 @@ bytes@3.0.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  integrity sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -332,10 +421,27 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
+camelcase@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.2.0.tgz#e7522abda5ed94cc0489e1b8466610e88404cf45"
+  integrity sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+chai@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
+  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.0"
+    type-detect "^4.0.5"
 
 chalk@2.3.0:
   version "2.3.0"
@@ -357,7 +463,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.1.0:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -370,6 +476,11 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
   integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 child-process-promise@^2.2.1:
   version "2.2.1"
@@ -389,6 +500,16 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
   integrity sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==
+
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
 
 cli-cursor@^2.1.0:
   version "2.1.0"
@@ -411,6 +532,15 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+    wrap-ansi "^2.0.0"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -420,6 +550,14 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  integrity sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=
+  dependencies:
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
 
 color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
@@ -489,6 +627,11 @@ common-tags@^1.4.0:
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
   integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
 
+component-emitter@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+  integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -528,6 +671,11 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
+
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+  integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js@^2.4.0:
   version "2.6.2"
@@ -574,24 +722,36 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@2.6.9, debug@^2.1.2:
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@3.2.6, debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.1.1:
+decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -607,6 +767,35 @@ deepmerge@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
   integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
+
+define-properties@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
+
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  integrity sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  integrity sha1-dp66rz9KY6rTr56NMEybvnm/sOY=
+  dependencies:
+    is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  integrity sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -633,6 +822,11 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+detect-file@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
+  integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
+
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
@@ -646,6 +840,11 @@ diagnostics@^1.1.1:
     colorspace "1.1.x"
     enabled "1.0.x"
     kuler "1.0.x"
+
+diff@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 dlv@^1.1.0:
   version "1.1.2"
@@ -701,12 +900,33 @@ env-variable@0.0.x:
   resolved "https://registry.yarnpkg.com/env-variable/-/env-variable-0.0.5.tgz#913dd830bef11e96a039c038d4130604eba37f88"
   integrity sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA==
 
+es-abstract@^1.5.1:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-keys "^1.0.12"
+
+es-to-primitive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -877,6 +1097,39 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  integrity sha1-t3c14xXOMPa27/D4OwQVGiJEliI=
+  dependencies:
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  integrity sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 express-github-webhook@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/express-github-webhook/-/express-github-webhook-1.0.6.tgz#a980ca0ab88b8cbda47b94a1e918c3f0a68f4cad"
@@ -920,6 +1173,21 @@ express@^4.16.4:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  integrity sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=
+  dependencies:
+    is-extendable "^0.1.0"
+
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  integrity sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
 extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
@@ -933,6 +1201,20 @@ external-editor@^2.0.4:
     chardet "^0.4.0"
     iconv-lite "^0.4.17"
     tmp "^0.0.33"
+
+extglob@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  integrity sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
+  dependencies:
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -994,6 +1276,16 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  integrity sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
+
 finalhandler@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.1.tgz#eebf4ed840079c83f4249038c9d703008301b105"
@@ -1014,6 +1306,23 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
+findup-sync@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
+  integrity sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=
+  dependencies:
+    detect-file "^1.0.0"
+    is-glob "^3.1.0"
+    micromatch "^3.0.4"
+    resolve-dir "^1.0.1"
+
 flat-cache@^1.2.1:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.4.tgz#2c2ef77525cc2929007dfffa1dd314aa9c9dee6f"
@@ -1023,6 +1332,18 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     rimraf "~2.6.2"
     write "^0.2.1"
+
+flat@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.0.tgz#090bec8b05e39cba309747f1d588f04dbaf98db2"
+  integrity sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==
+  dependencies:
+    is-buffer "~2.0.3"
+
+for-in@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+  integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -1042,6 +1363,13 @@ forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
+
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
+  dependencies:
+    map-cache "^0.2.2"
 
 fresh@0.5.2:
   version "0.5.2"
@@ -1084,6 +1412,11 @@ fstream@^1.0.0, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
@@ -1108,6 +1441,11 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+
 get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
@@ -1118,6 +1456,18 @@ get-stream@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
+get-stream@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
+
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
+  integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
+
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
@@ -1125,7 +1475,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@7.1.3, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -1149,6 +1499,26 @@ glob@~7.0.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-modules@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
+  integrity sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==
+  dependencies:
+    global-prefix "^1.0.1"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
+
+global-prefix@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
+  integrity sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
+
 globals@^11.0.1:
   version "11.10.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.10.0.tgz#1e09776dffda5e01816b3bb4077c8b59c24eaa50"
@@ -1158,6 +1528,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
 handlebars@^4.0.12:
   version "4.0.12"
@@ -1200,10 +1575,65 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
+
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  integrity sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=
+  dependencies:
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
+
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  integrity sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
+
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+  integrity sha1-bWHeldkd/Km5oCCJrThL/49it3E=
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  integrity sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
+
+has@^1.0.1, has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
+
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+homedir-polyfill@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
+  integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
+  dependencies:
+    parse-passwd "^1.0.0"
 
 http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
   version "1.6.3"
@@ -1273,7 +1703,7 @@ inherits@2, inherits@2.0.3, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@~1.3.0:
+ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -1303,6 +1733,11 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
+invert-kv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
+  integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
 ip-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-3.0.0.tgz#0a934694b4066558c46294244a23cc33116bf732"
@@ -1313,10 +1748,93 @@ ipaddr.js@1.8.0:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
   integrity sha1-6qM9bd16zo9/b+DJygRA5wZzix4=
 
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  integrity sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
+  dependencies:
+    kind-of "^6.0.0"
+
 is-arrayish@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
   integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
+is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
+  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
+
+is-callable@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
+
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  integrity sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
+  dependencies:
+    kind-of "^6.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  integrity sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  integrity sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
+
+is-extendable@^0.1.0, is-extendable@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+  integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
+
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
+  dependencies:
+    is-plain-object "^2.0.4"
+
+is-extglob@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -1330,7 +1848,21 @@ is-fullwidth-code-point@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
-is-plain-object@^2.0.4:
+is-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
+  integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
+  dependencies:
+    is-extglob "^2.1.0"
+
+is-number@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
+  integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
+  dependencies:
+    kind-of "^3.0.2"
+
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
@@ -1342,6 +1874,13 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
+  dependencies:
+    has "^1.0.1"
+
 is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
@@ -1352,12 +1891,24 @@ is-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  dependencies:
+    has-symbols "^1.0.0"
+
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-isarray@~1.0.0:
+is-windows@^1.0.1, is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+  integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -1367,7 +1918,14 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-isobject@^3.0.1:
+isobject@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
+  integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
+  dependencies:
+    isarray "1.0.0"
+
+isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
@@ -1386,6 +1944,14 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
+
+js-yaml@3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 js-yaml@^3.12.1, js-yaml@^3.9.1:
   version "3.12.1"
@@ -1442,6 +2008,30 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+
 kuler@1.0.x:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/kuler/-/kuler-1.0.1.tgz#ef7c784f36c9fb6e16dd3150d152677b2b0228a6"
@@ -1455,6 +2045,13 @@ lcid@^1.0.0:
   integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
   dependencies:
     invert-kv "^1.0.0"
+
+lcid@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
+  integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
+  dependencies:
+    invert-kv "^2.0.0"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -1470,6 +2067,14 @@ locate-path@^2.0.0:
   integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
   dependencies:
     p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
     path-exists "^3.0.0"
 
 lodash.get@^4.4.2:
@@ -1506,6 +2111,13 @@ lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+log-symbols@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
+  dependencies:
+    chalk "^2.0.1"
 
 logform@^1.9.1:
   version "1.10.0"
@@ -1556,10 +2168,29 @@ make-plural@^4.1.1:
   optionalDependencies:
     minimist "^1.2.0"
 
+map-age-cleaner@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
+
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+  integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
+
 map-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
   integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
+
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
+  dependencies:
+    object-visit "^1.0.0"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -1572,6 +2203,15 @@ mem@^1.1.0:
   integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
   dependencies:
     mimic-fn "^1.0.0"
+
+mem@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-4.2.0.tgz#5ee057680ed9cb8dad8a78d820f9a8897a102025"
+  integrity sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==
+  dependencies:
+    map-age-cleaner "^0.1.1"
+    mimic-fn "^2.0.0"
+    p-is-promise "^2.0.0"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -1599,6 +2239,25 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
+micromatch@^3.0.4:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
+  integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.2"
+
 mime-db@~1.37.0:
   version "1.37.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
@@ -1621,7 +2280,12 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
-minimatch@^3.0.2, minimatch@^3.0.4:
+mimic-fn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.0.0.tgz#0913ff0b121db44ef5848242c38bbb35d44cabde"
+  integrity sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==
+
+minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -1658,19 +2322,56 @@ minizlib@^1.1.1:
   dependencies:
     minipass "^2.2.1"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
+mixin-deep@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  integrity sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
+
+mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
 
+mocha@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-6.0.2.tgz#cdc1a6fdf66472c079b5605bac59d29807702d2c"
+  integrity sha512-RtTJsmmToGyeTznSOMoM6TPEk1A84FQaHIciKrRqARZx+B5ccJ5tXlmJzEKGBxZdqk9UjpRsesZTUkZmR5YnuQ==
+  dependencies:
+    ansi-colors "3.2.3"
+    browser-stdout "1.3.1"
+    debug "3.2.6"
+    diff "3.5.0"
+    escape-string-regexp "1.0.5"
+    findup-sync "2.0.0"
+    glob "7.1.3"
+    growl "1.10.5"
+    he "1.2.0"
+    js-yaml "3.12.0"
+    log-symbols "2.2.0"
+    minimatch "3.0.4"
+    mkdirp "0.5.1"
+    ms "2.1.1"
+    node-environment-flags "1.0.4"
+    object.assign "4.1.0"
+    strip-json-comments "2.0.1"
+    supports-color "6.0.0"
+    which "1.3.1"
+    wide-align "1.1.3"
+    yargs "12.0.5"
+    yargs-parser "11.1.1"
+    yargs-unparser "1.5.0"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.1.1:
+ms@2.1.1, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
@@ -1684,6 +2385,23 @@ nan@^2.11.1:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
   integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
+
+nanomatch@^1.2.9:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
+  integrity sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -1715,6 +2433,13 @@ no-case@^2.2.0:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
+
+node-environment-flags@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.4.tgz#0b784a6551426bfc16d3b2208424dcbc2b2ff038"
+  integrity sha512-M9rwCnWVLW7PX+NUWe3ejEdiLYinRpsEre9hMkU/6NS4h+EEulYaDH1gCEZ2gyXsmw+RXYDaV2JkkTNcsPDJ0Q==
+  dependencies:
+    object.getownpropertydescriptors "^2.0.3"
 
 node-fetch@^2.3.0:
   version "2.3.0"
@@ -1842,6 +2567,52 @@ object-assign@^4.0.1, object-assign@^4.1.0:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  integrity sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
+
+object-keys@^1.0.11, object-keys@^1.0.12:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
+  integrity sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==
+
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
+  dependencies:
+    isobject "^3.0.0"
+
+object.assign@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
+
+object.getownpropertydescriptors@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
+  integrity sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.1"
+
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
+  dependencies:
+    isobject "^3.0.1"
+
 octokit-pagination-methods@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
@@ -1907,6 +2678,15 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
+os-locale@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
+  integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
+  dependencies:
+    execa "^1.0.0"
+    lcid "^2.0.0"
+    mem "^4.0.0"
+
 os-name@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/os-name/-/os-name-3.0.0.tgz#e1434dbfddb8e74b44c98b56797d951b7648a5d9"
@@ -1928,10 +2708,20 @@ osenv@0, osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-is-promise@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.0.0.tgz#7554e3d572109a87e1f3f53f6a7d85d1b194f4c5"
+  integrity sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -1940,6 +2730,13 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
+  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -1947,15 +2744,37 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
+p-try@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.1.0.tgz#c1a0f1030e97de018bb2c718929d2af59463e505"
+  integrity sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==
+
+parse-passwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
+  integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
+
 parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
   integrity sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=
+
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+  integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -1982,6 +2801,11 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+pathval@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -1991,6 +2815,11 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
+
+posix-character-classes@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
+  integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -2101,6 +2930,14 @@ pump@^1.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -2169,10 +3006,28 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+  integrity sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==
+  dependencies:
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
+
 regexpp@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
   integrity sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==
+
+repeat-element@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
+  integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
+
+repeat-string@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
 request-promise-core@1.1.1:
   version "1.1.1"
@@ -2180,6 +3035,13 @@ request-promise-core@1.1.1:
   integrity sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=
   dependencies:
     lodash "^4.13.1"
+
+request-promise-core@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"
+  integrity sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==
+  dependencies:
+    lodash "^4.17.11"
 
 request-promise-native@^1.0.5:
   version "1.0.5"
@@ -2189,6 +3051,15 @@ request-promise-native@^1.0.5:
     request-promise-core "1.1.1"
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
+
+request-promise-native@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.7.tgz#a49868a624bdea5069f1251d0a836e0d89aa2c59"
+  integrity sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==
+  dependencies:
+    request-promise-core "1.1.2"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
 
 request@^2.87.0, request@^2.88.0:
   version "2.88.0"
@@ -2249,10 +3120,23 @@ reserved-words@^0.1.2:
   resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
   integrity sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=
 
+resolve-dir@^1.0.0, resolve-dir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
+  integrity sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^1.0.0"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
   integrity sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=
+
+resolve-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+  integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -2261,6 +3145,11 @@ restore-cursor@^2.0.0:
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
 rimraf@2, rimraf@^2.6.1, rimraf@~2.6.2:
   version "2.6.3"
@@ -2304,6 +3193,13 @@ safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, s
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  integrity sha1-QKNmnzsHfR6UPURinhV91IAjvy4=
+  dependencies:
+    ret "~0.1.10"
 
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
@@ -2364,6 +3260,26 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  integrity sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
+
 setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
@@ -2407,10 +3323,68 @@ snake-case@^2.1.0:
   dependencies:
     no-case "^2.2.0"
 
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  integrity sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==
+  dependencies:
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  integrity sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
+  dependencies:
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
+  integrity sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^3.1.0"
+
+source-map-resolve@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
+  integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
+  dependencies:
+    atob "^2.1.1"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+  integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
+
+source-map@^0.5.6:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+
 source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
+  dependencies:
+    extend-shallow "^3.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -2437,6 +3411,14 @@ stack-trace@0.0.x:
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  integrity sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=
+  dependencies:
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
+
 "statuses@>= 1.4.0 < 2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
@@ -2447,7 +3429,7 @@ statuses@~1.4.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
   integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
 
-stealthy-require@^1.1.0:
+stealthy-require@^1.1.0, stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
@@ -2495,10 +3477,17 @@ strip-eof@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
-strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+supports-color@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.0.0.tgz#76cfe742cf1f41bb9b1c29ad03068c05b4c0e40a"
+  integrity sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==
+  dependencies:
+    has-flag "^3.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -2608,12 +3597,45 @@ to-buffer@^1.1.1:
   resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
   integrity sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==
 
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
+  dependencies:
+    kind-of "^3.0.2"
+
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  integrity sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+
+to-regex@^3.0.1, to-regex@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  integrity sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==
+  dependencies:
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
+
 tough-cookie@>=2.3.3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-3.0.0.tgz#d2bceddebde633153ff20a52fa844a0dc71dacef"
   integrity sha512-LHMvg+RBP/mAVNqVbOX8t+iJ+tqhBA/t49DuI7+IDAWHrASnesqSu1vWbKB7UrE2yk+HMFUBMadRGMkB4VCfog==
   dependencies:
     ip-regex "^3.0.0"
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
+tough-cookie@^2.3.3:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
     psl "^1.1.28"
     punycode "^2.1.1"
 
@@ -2649,6 +3671,11 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
 type-is@~1.6.16:
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
@@ -2683,6 +3710,16 @@ uglify-js@^3.1.4:
     commander "~2.17.1"
     source-map "~0.6.1"
 
+union-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  integrity sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=
+  dependencies:
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^0.4.3"
+
 universal-user-agent@^2.0.0, universal-user-agent@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-2.0.3.tgz#9f6f09f9cc33de867bb720d84c08069b14937c6c"
@@ -2700,6 +3737,14 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
+unset-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  integrity sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=
+  dependencies:
+    has-value "^0.3.1"
+    isobject "^3.0.0"
+
 uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
@@ -2707,10 +3752,20 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+urix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+  integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
 url-template@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
   integrity sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
+
+use@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
+  integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -2758,14 +3813,14 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@1, which@^1.2.9:
+which@1, which@1.3.1, which@^1.2.14, which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
-wide-align@^1.1.0:
+wide-align@1.1.3, wide-align@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
@@ -2842,6 +3897,11 @@ y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
   integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
 
+"y18n@^3.2.1 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -2852,12 +3912,29 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
+yargs-parser@11.1.1, yargs-parser@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
+  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^8.0.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
   integrity sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==
   dependencies:
     camelcase "^4.1.0"
+
+yargs-unparser@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-1.5.0.tgz#f2bb2a7e83cbc87bb95c8e572828a06c9add6e0d"
+  integrity sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==
+  dependencies:
+    flat "^4.1.0"
+    lodash "^4.17.11"
+    yargs "^12.0.5"
 
 yargs@10.0.3:
   version "10.0.3"
@@ -2876,3 +3953,21 @@ yargs@10.0.3:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^8.0.0"
+
+yargs@12.0.5, yargs@^12.0.5:
+  version "12.0.5"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
+  integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^1.0.1"
+    os-locale "^3.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1 || ^4.0.0"
+    yargs-parser "^11.1.1"


### PR DESCRIPTION
Added tests using mocha & chai. Set up CircleCI pipeline. Refactored code to make testing easier (or, you know, possible).

Sorry this is quite a big PR, but there actually not *that* much changed contrary to what an overlook at the diff may suggest. Mostly this is just moving code around, there is no logic changes (except for maybe a few small fixes to bugs that were discovered while writing tests). Overall, changes to the code can be summarized as follows:

- Created a registry module for dependency injection (`lib/injections.js`). This was done to allow easy mocking of modules (internal and 3rd party) during tests, and do proper unit testing. It provides 3 primitives:
  - `register(name, value)` allows registering things into the registry. A shorthand version `register(Class)` is equivalent to calling `register('Class', Class)`.
  - `registerLazy(name, () => value)` allows lazy registration (useful for singleton-like stuff).
  - `lookup(name)` allows getting values from the registry. It supports the shorthand version `let { name1, name2 } = lookup()` because I thought it is a neat syntax and avoids repetition (compare that to `let name1 = lookup('name1'); let name2 = lookup('name2)`)
- In all the code, removed most internal and some 3rd party `require` calls  and replaced them by `lookup` calls done very close to the code that actually uses the dependencies.
- In all the code, removed most `module.exports` calls and replaced them with `register[Lazy]` calls.
- Added a `loadModules` method in `lib/peon.js` to load all internal modules (so that they have the opportunity to register themselves) and add 3rd party modules to the registry.
- Refactored some modules so that unit testing of single methods is easier : some POJOs were rewritten as classes, some getters were added to generate stuff from modules in the registry (config, queues, loggers mostly). Also took the opportunity to separate status stuff a bit better (github status updates, status page rendering).

As far as the tests are concerned, the `test/helpers.js` module provides helpers (duh) to mock stuff in the registry, mock config values, and create temporary directories for tests where FS interaction is at play (I didn't push the dep injection thingy as far as mocking `fs` because that looked overkill). Those also auto-cleanup after each test (thanks to the `afterEach` hook registered in `test/init.js`).

Closes #22