### PR TITLE
feat: abort stale builds on startup (JS-66)

### DIFF
--- a/lib/peon.js
+++ b/lib/peon.js
@@ -37,10 +37,13 @@ class Peon {
         watcher: { enabled: watcherEnabled, repositories: watcherRepositories },
         webhooks: { enabled: webhooksEnabled }
       },
-      misc: { extractRepoName }
+      misc: { extractRepoName },
+      status
     } = lookup()
 
     this.logger.info('Starting peon...', { module: 'peon' })
+
+    await status.abortStaleBuilds()
 
     this.watchers = []
     if (watcherEnabled) {

--- a/lib/status/status.js
+++ b/lib/status/status.js
@@ -1,5 +1,5 @@
 const { resolve } = require('path')
-const { mkdir, readFile, writeFile } = require('fs-extra')
+const { mkdir, readdir, readFile, writeFile } = require('fs-extra')
 
 const { lookup, register, registerLazy } = require('../injections')
 
@@ -8,7 +8,59 @@ class Status {
     let {
       config: { workingDirectory }
     } = lookup()
+
     return resolve(workingDirectory, 'status')
+  }
+
+  async abortStaleBuilds() {
+    let { statusRoot } = this
+    let { githubStatus, renderer } = lookup()
+    let didSomething = false
+    let now = Date.now()
+
+    await this._ensureDirsExist()
+
+    for (let file of await readdir(statusRoot)) {
+      if (file === 'peon-status.json') {
+        continue
+      }
+
+      let status = JSON.parse(await readFile(resolve(statusRoot, file)))
+      let changed = false
+
+      for (let buildId in status.builds) {
+        let build = status.builds[buildId]
+        if (build.status !== 'pending' && build.status !== 'running') {
+          continue
+        }
+
+        didSomething = changed = true
+        build.status = 'cancelled'
+        build.updated = now
+
+        let runningStep = build.steps.find((s) => s.status === 'running')
+        if (runningStep) {
+          runningStep.status = 'failed'
+          runningStep.output = 'stale build was aborted'
+        }
+
+        githubStatus.update(
+          build.url,
+          buildId,
+          build.sha,
+          'error',
+          'Peon stale build was aborted'
+        )
+      }
+
+      if (changed) {
+        await writeFile(resolve(statusRoot, file), JSON.stringify(status))
+      }
+    }
+
+    if (didSomething) {
+      await renderer.render(Date.now())
+    }
   }
 
   async _ensureDirsExist() {

--- a/test/unit/peon.test.js
+++ b/test/unit/peon.test.js
@@ -1,10 +1,37 @@
 /* eslint-disable camelcase */
 
 const { assert } = require('chai')
-const { src, mock, mockConfig } = require('../helpers')
+const { src, mock, mockConfig, tempDir } = require('../helpers')
 const Peon = require(`${src}/peon`)
 
 describe('unit | peon', function() {
+  beforeEach(async() => {
+    let workingDirectory = await tempDir()
+    mockConfig('workingDirectory', workingDirectory)
+  })
+
+  describe('status', function() {
+    it('aborts stale builds on startup', async function() {
+      let aborted = false
+
+      mock('status', {
+        async abortStaleBuilds() {
+          aborted = true
+        }
+      })
+
+      mockConfig('watcher', {
+        enabled: false
+      })
+
+      mockConfig('webhooks', { enabled: false })
+
+      await new Peon().start()
+
+      assert.ok(aborted)
+    })
+  })
+
   describe('watchers', function() {
     it('starts a watcher for each configured repository', async function() {
       let watchers = []


### PR DESCRIPTION
When starting peon, lookup builds that were running/pending and mark them as cancelled, updating github commit statuses, and re-rendering status pages.

Closes #27
Refs https://people-doc.atlassian.net/browse/JS-66