### PR TITLE
feat: cache max size (JS-67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ The configuration file contains the following keys:
 - **Base configuration:**
   - `workingDirectory`: a directory where peon stores its working data
   - `cacheValidity`: validity in milliseconds of paths cached during builds.
+  - `cacheMaxSize`: maximum size of cache in bytes; peon will remove the oldest
+    non-expired cache items until cache size is below that limit. Set to 0 for
+    unlimited cache size.
   - `statusDirectory`: a directory where peon will store its status pages.
   - `statusUrl`: URL where the status directory is served (used for github
     build status updates)

--- a/config.sample.json
+++ b/config.sample.json
@@ -38,6 +38,7 @@
   },
 
   "cacheValidity": 2592000000,
+  "cacheMaxSize": 0,
   "workingDirectory": "./data",
   "statusDirectory": "/var/www/html/peon-status",
   "statusUrl": "https://my.host/peon-status/",

--- a/lib/build/cache.js
+++ b/lib/build/cache.js
@@ -55,18 +55,32 @@ class Cache {
   async _pruneCache() {
     let { cacheDirectory, logger } = this
     let {
-      config: { cacheValidity }
+      config: { cacheValidity, cacheMaxSize }
     } = lookup()
 
     let minMtime = Date.now() - cacheValidity
+    let items = []
 
     for (let file of await readdir(cacheDirectory)) {
       let filePath = resolve(cacheDirectory, file)
       let fileStat = await stat(filePath)
+
       if (fileStat.mtimeMs < minMtime) {
         logger.debug(`removing expired ${file}`, { module: 'cache' })
         await unlink(filePath)
+      } else {
+        items.push({ file, mtime: fileStat.mtimeMs, size: fileStat.size })
       }
+    }
+
+    items.sort((a, b) => a.mtime - b.mtime)
+    while (
+      cacheMaxSize > 0
+      && items.reduce((total, { size }) => total + size, 0) > cacheMaxSize
+    ) {
+      let { file } = items.shift()
+      logger.debug(`removing ${file} to reduce cache size`, { module: 'cache' })
+      await unlink(resolve(cacheDirectory, file))
     }
   }
 

--- a/test/unit/build/cache.test.js
+++ b/test/unit/build/cache.test.js
@@ -93,6 +93,31 @@ describe('unit | build/cache', function() {
         'valid2'
       ])
     })
+
+    it('removes non expired entries when cache size is too big', async function() {
+      let validitySeconds = 60
+      let validUnixTime = Date.now() / 1000 - validitySeconds / 2
+
+      mockConfig('cacheValidity', validitySeconds * 1000)
+      mockConfig('cacheMaxSize', 10)
+
+      let cache = new Cache()
+      await cache._ensureCacheDirExists()
+
+      await writeFile(resolve(workingDirectory, 'cache', 'valid1'), 'content')
+      await utimes(
+        resolve(workingDirectory, 'cache', 'valid1'),
+        validUnixTime,
+        validUnixTime
+      )
+      await writeFile(resolve(workingDirectory, 'cache', 'valid2'), 'content')
+
+      await cache._pruneCache()
+
+      assert.deepEqual(await readdir(resolve(workingDirectory, 'cache')), [
+        'valid2'
+      ])
+    })
   })
 
   describe('Cache.saveCache', function() {


### PR DESCRIPTION
Add a setting for maximum cache size in bytes.

When pruning cache, if the limit is set to a positive number, peon will remove even non-expired files, starting with the oldest ones, until total cache size is below that limit.

Closes #29
Refs https://people-doc.atlassian.net/browse/JS-67