### PR TITLE
Cleanup builds and misc fixes

### DIFF
--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -72,7 +72,7 @@ class Build {
       await this._runStep('create workspace', () => this._createWorkspace())
       await this._runStep('read .peon.yml', () => this._readPeonConfig())
 
-      let { env, peonConfig } = this
+      let { peonConfig } = this
 
       if (peonConfig.cache && peonConfig.cache.length) {
         await this._runStep('restore cache', () => this._restoreCache())
@@ -88,20 +88,9 @@ class Build {
         await this._runStep('save cache', () => this._saveCache())
       }
 
-      await this._runStep('deploy', () => this._deploy())
+      let deployData = await this._runStep('deploy', () => this._deploy())
 
-      let {
-        destination: { absoluteUrl },
-        pathInDestination
-      } = this
-
-      // We cannot use path.join here because of the protocol:// prefix
-      if (!absoluteUrl.endsWith('/')) {
-        absoluteUrl = `${absoluteUrl}/`
-      }
-      await status.finishBuild(buildId, 'success', {
-        outputURL: `${absoluteUrl}${env.evaluate(pathInDestination)}`
-      })
+      await status.finishBuild(buildId, 'success', deployData)
     } catch(e) {
       if (e instanceof CancelBuild) {
         this.info(`cancelled build, ${e.message}`)
@@ -466,6 +455,16 @@ class Build {
     }
 
     this.info(`built ${sha} successfully`)
+
+    let { absoluteUrl } = destination
+    if (!absoluteUrl.endsWith('/')) {
+      absoluteUrl = `${absoluteUrl}/`
+    }
+
+    return {
+      outputURL: `${absoluteUrl}${evaluatedPathInDest}`,
+      localDirectory: isRemote ? null : destDir
+    }
   }
 }
 

--- a/lib/build/cache.js
+++ b/lib/build/cache.js
@@ -7,7 +7,7 @@ class Cache {
   get logger() {
     if (!this._logger) {
       let { getLogger } = lookup()
-      this._logger = getLogger('build')
+      this._logger = getLogger('cache')
     }
     return this._logger
   }

--- a/lib/build/dispatcher.js
+++ b/lib/build/dispatcher.js
@@ -25,22 +25,48 @@ class Dispatcher {
       return
     }
 
-    let { status, Build } = lookup()
-    let buildId = await status.startBuild(
-      repoConfig.url,
-      repoConfig.name,
-      repoConfig.refMode,
-      repoConfig.ref,
-      payload.head_commit.id
-    )
+    if (payload.head_commit) {
+      // Head commit is present, branch was pushed
 
-    let build = new Build(buildId, payload, repoConfig)
+      let { status, Build } = lookup()
+      let buildId = await status.startBuild(
+        repoConfig.url,
+        repoConfig.name,
+        repoConfig.refMode,
+        repoConfig.ref,
+        payload.head_commit.id
+      )
 
-    logger.debug(`enqueuing build ${buildId}`, {
-      module: `dispatcher/${repoConfig.name}`
-    })
+      if (!buildId) {
+        logger.error('could not create build')
+        return
+      }
 
-    this.queue.run(() => build.build())
+      let build = new Build(buildId, payload, repoConfig)
+
+      logger.debug(`enqueuing build ${buildId}`, {
+        module: `dispatcher/${repoConfig.name}`
+      })
+
+      this.queue.run(() => build.build())
+    } else {
+      // No head commit, branch was removed
+
+      let { status } = lookup()
+
+      logger.debug(
+        `enqueuing cleanup job for ${repoConfig.refMode} ${repoConfig.ref}`,
+        { module: `dispatcher/${repoConfig.name}` }
+      )
+
+      this.queue.run(() =>
+        status.cleanupLocalBuilds(
+          repoConfig.name,
+          repoConfig.refMode,
+          repoConfig.ref
+        )
+      )
+    }
   }
 
   findRepository(eventType, payload) {

--- a/lib/status/github.js
+++ b/lib/status/github.js
@@ -62,7 +62,7 @@ class GithubStatus {
           this.logger.warn('could not update GitHub status', {
             module: 'status/github'
           })
-          this.logger.warn(e.stack)
+          this.logger.warn(e.stack, { module: 'status/github' })
         })
     )
   }

--- a/lib/status/render.js
+++ b/lib/status/render.js
@@ -138,18 +138,28 @@ class Renderer {
         }
       }
 
-      await writeFile(
-        resolve(statusDirectory, repoName, `${buildNum}.html`),
-        buildTemplate(
-          Object.assign(
-            {
-              buildId,
-              isRunning: ['pending', 'running'].indexOf(buildData.status) !== -1
-            },
-            buildData
+      try {
+        await writeFile(
+          resolve(statusDirectory, repoName, `${buildNum}.html`),
+          buildTemplate(
+            Object.assign(
+              {
+                buildId,
+                isRunning:
+                  ['pending', 'running'].indexOf(buildData.status) !== -1
+              },
+              buildData
+            )
           )
         )
-      )
+      } catch(e) {
+        logger.error(`error rendering ${repoName}/${buildNum}.html`, {
+          module: 'status/render'
+        })
+        logger.error(e.stack, { module: 'status/render' })
+
+        throw e
+      }
     }
   }
 
@@ -216,14 +226,21 @@ class Renderer {
 
     // Render index
     logger.debug('rendering index', { module: 'status/render' })
-    await writeFile(
-      resolve(statusDirectory, 'index.html'),
-      indexTemplate({
-        repos: reposStatus,
-        now,
-        hasData: Object.keys(reposStatus).length > 0
-      })
-    )
+
+    try {
+      await writeFile(
+        resolve(statusDirectory, 'index.html'),
+        indexTemplate({
+          repos: reposStatus,
+          now,
+          hasData: Object.keys(reposStatus).length > 0
+        })
+      )
+    } catch(e) {
+      logger.error('error rendering index', { module: 'status/render' })
+      logger.error(e.stack, { module: 'status/render' })
+      throw e
+    }
   }
 
   async render(now) {

--- a/lib/status/status.js
+++ b/lib/status/status.js
@@ -1,5 +1,5 @@
 const { resolve } = require('path')
-const { mkdir, readFile, writeFile } = require('fs-extra')
+const { mkdir, readFile, remove, writeFile } = require('fs-extra')
 
 const { lookup, register, registerLazy } = require('../injections')
 
@@ -9,6 +9,14 @@ class Status {
       config: { workingDirectory }
     } = lookup()
     return resolve(workingDirectory, 'status')
+  }
+
+  get logger() {
+    if (!this._logger) {
+      let { getLogger } = lookup()
+      this._logger = getLogger('status')
+    }
+    return this._logger
   }
 
   async _ensureDirsExist() {
@@ -143,6 +151,39 @@ class Status {
       build.updated = now
       build.duration = build.end - build.start
       build.extra = extra
+    })
+  }
+
+  async cleanupLocalBuilds(repoName, refMode, ref) {
+    let { logger } = this
+
+    logger.info(
+      `cleaning up local builds for ${refMode} ${ref} on ${repoName}`,
+      { module: 'status' }
+    )
+
+    await this._updateRepoStatus(repoName, async(repoStatus) => {
+      for (let buildId in repoStatus.builds) {
+        let build = repoStatus.builds[buildId]
+        let { branch, tag, status, extra } = build
+
+        if (
+          ((refMode === 'branch' && branch === ref)
+            || (refMode === 'tag' && tag === ref))
+          && status == 'success'
+          && extra
+          && extra.localDirectory
+          && !extra.localCleaned
+        ) {
+          logger.debug(
+            `removing local build ${buildId} at ${extra.localDirectory}`,
+            { module: 'status' }
+          )
+
+          await remove(extra.localDirectory)
+          extra.localCleaned = true
+        }
+      }
     })
   }
 }

--- a/lib/status/status.js
+++ b/lib/status/status.js
@@ -138,7 +138,7 @@ class Status {
         build.url,
         buildId,
         build.sha,
-        buildStatus === 'success' ? 'success' : 'failed',
+        buildStatus === 'success' ? 'success' : 'failure',
         buildStatus === 'success'
           ? 'Peon build is finished'
           : buildStatus === 'cancelled'

--- a/lib/status/status.js
+++ b/lib/status/status.js
@@ -32,29 +32,44 @@ class Status {
   }
 
   async _updateRepoStatus(repoName, updater) {
-    let { statusRoot } = this
+    let { logger, statusRoot } = this
     let ret, repoStatus
     let now = Date.now()
 
-    await this._ensureDirsExist()
-
-    let statusFile = resolve(statusRoot, `${repoName}.json`)
-
     try {
-      repoStatus = JSON.parse(await readFile(statusFile))
-    } catch(e) {
-      repoStatus = {
-        nextBuildNum: 1,
-        builds: {}
+      await this._ensureDirsExist()
+
+      let statusFile = resolve(statusRoot, `${repoName}.json`)
+
+      try {
+        repoStatus = JSON.parse(await readFile(statusFile))
+      } catch(e) {
+        repoStatus = {
+          nextBuildNum: 1,
+          builds: {}
+        }
       }
+
+      ret = await updater(repoStatus, now)
+
+      await writeFile(statusFile, JSON.stringify(repoStatus))
+    } catch(e) {
+      logger.error(`could not update status for ${repoName}`, {
+        module: 'status'
+      })
+      logger.error(e.stack, { module: 'status' })
+      return
     }
 
-    ret = updater(repoStatus, now)
-
-    await writeFile(statusFile, JSON.stringify(repoStatus))
-
     let { renderer } = lookup()
-    await renderer.render(Date.now())
+
+    try {
+      await renderer.render(Date.now())
+    } catch(e) {
+      logger.error('could not render status pages', { module: 'status' })
+      logger.error(e.stack, { module: 'status' })
+      return
+    }
 
     return ret
   }

--- a/scripts/webhook.js
+++ b/scripts/webhook.js
@@ -8,12 +8,12 @@
 
   Call this script as:
 
-    ./scripts/webhooks.js URL REF SHA
+    ./scripts/webhooks.js URL REF [SHA]
 
   Where:
     URL is the repository URL
     REF is a full git ref (refs/heads/mybranch or refs/tags/mytag)
-    SHA is a commit SHA.
+    SHA is a commit SHA; if omitted, the payload will simulate a deleted branch
 
   Note: this does not generate full payloads, only the parts that peon cares
   about.  It must be updated when peon has new expectations.
@@ -27,15 +27,15 @@ const {
   webhooks: { port, secret }
 } = require('../lib/config')
 
-if (process.argv.length !== 5) {
+if (process.argv.length < 4 || process.argv.length > 5) {
   // eslint-disable-next-line no-console
-  console.error(`Usage: ${process.argv[1]} URL REF SHA`)
+  console.error(`Usage: ${process.argv[1]} URL REF [SHA]`)
   process.exit(1)
 }
 
 const payload = {
   ref: process.argv[3],
-  head_commit: { id: process.argv[4] },
+  head_commit: process.argv[4] && { id: process.argv[4] },
   repository: {
     name: extractRepoName(process.argv[2]),
     ssh_url: process.argv[2]

--- a/test/unit/status/status.test.js
+++ b/test/unit/status/status.test.js
@@ -448,7 +448,7 @@ describe('unit | status/status', function() {
       ])
     })
 
-    it('sends a "failed" github status update when build status is failed', async function() {
+    it('sends a "failure" github status update when build status is failed', async function() {
       let updater, ghArgs
 
       let status = new Status()
@@ -471,12 +471,12 @@ describe('unit | status/status', function() {
         'repo/url',
         'reponame#100',
         'sha',
-        'failed',
+        'failure',
         'Peon build has failed'
       ])
     })
 
-    it('sends a "failed" github status update when build status is cancelled', async function() {
+    it('sends a "failure" github status update when build status is cancelled', async function() {
       let updater, ghArgs
 
       let status = new Status()
@@ -499,7 +499,7 @@ describe('unit | status/status', function() {
         'repo/url',
         'reponame#100',
         'sha',
-        'failed',
+        'failure',
         'Peon build was cancelled'
       ])
     })


### PR DESCRIPTION
In this PR:

* Cleanup builds when branches are deleted
	* We receive a webhook with no `head_commit` in the payload when a branch is deleted. Previously this was triggering an error. Now we enqueue a cleanup job.
	* When deploying locally, store the path where the build was deployed in the build status file.
	* When a cleanup job runs, it checks for locally deployed builds for that repo+branch/tag, removes the local build, and marks it as removed.
* Misc fixes
	* Fix some missing/wrong logger identifiers
	* Fix wrong github status set when the build has failed; the correct status is "failure" and we tried to set "failed".
	* Be more verbose when status updates or status page renders fail, so that we can see more clearly what happens in the logs.

Closes #18 