### PR TITLE
feat: cleanup local builds

### DIFF
--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -72,10 +72,12 @@ class Build {
       await this._runStep('create workspace', () => this._createWorkspace())
       await this._runStep('read .peon.yml', () => this._readPeonConfig())
 
-      let { env, peonConfig } = this
+      let { peonConfig } = this
 
       if (peonConfig.cache && peonConfig.cache.length) {
-        await this._runStep('restore cache', () => this._restoreCache())
+        await this._runStep('restore cache', (updateOutput) =>
+          this._restoreCache(updateOutput)
+        )
       }
 
       for (let command of peonConfig.commands) {
@@ -85,23 +87,14 @@ class Build {
       }
 
       if (peonConfig.cache && peonConfig.cache.length) {
-        await this._runStep('save cache', () => this._saveCache())
+        await this._runStep('save cache', (updateOutput) =>
+          this._saveCache(updateOutput)
+        )
       }
 
-      await this._runStep('deploy', () => this._deploy())
+      let deployData = await this._runStep('deploy', () => this._deploy())
 
-      let {
-        destination: { absoluteUrl },
-        pathInDestination
-      } = this
-
-      // We cannot use path.join here because of the protocol:// prefix
-      if (!absoluteUrl.endsWith('/')) {
-        absoluteUrl = `${absoluteUrl}/`
-      }
-      await status.finishBuild(buildId, 'success', {
-        outputURL: `${absoluteUrl}${env.evaluate(pathInDestination)}`
-      })
+      await status.finishBuild(buildId, 'success', deployData)
     } catch(e) {
       if (e instanceof CancelBuild) {
         this.info(`cancelled build, ${e.message}`)
@@ -134,9 +127,9 @@ class Build {
     this.debug(`running step: ${stepName}`)
     await updateStep('running')
 
-    let output
+    let ret
     try {
-      output = await step(updateOutput)
+      ret = await step(updateOutput)
       await updateQueue.join()
     } catch(e) {
       await updateQueue.join()
@@ -152,7 +145,9 @@ class Build {
       }
     }
 
-    await updateStep('success', output)
+    await updateStep('success')
+
+    return ret
   }
 
   async _updateRepository() {
@@ -312,7 +307,7 @@ class Build {
     )
   }
 
-  async _restoreCache() {
+  async _restoreCache(updateOutput) {
     let { repoName, workspace, peonConfig } = this
     let { cache } = lookup()
 
@@ -323,15 +318,17 @@ class Build {
         peonConfig.cache
       )
 
-      return restoredPaths.length
-        ? `restored paths ${restoredPaths.join(', ')}`
-        : 'found nothing to restore'
+      updateOutput(
+        restoredPaths.length
+          ? `restored paths ${restoredPaths.join(', ')}`
+          : 'found nothing to restore'
+      )
     } catch(e) {
       throw new BuildWarning(e)
     }
   }
 
-  async _saveCache() {
+  async _saveCache(updateOutput) {
     let { repoName, workspace, peonConfig } = this
     let { cache } = lookup()
 
@@ -341,9 +338,11 @@ class Build {
         workspace,
         peonConfig.cache
       )
-      return savedPaths.length
-        ? `saved paths ${savedPaths.join(', ')}`
-        : 'found nothing to save'
+      updateOutput(
+        savedPaths.length
+          ? `saved paths ${savedPaths.join(', ')}`
+          : 'found nothing to save'
+      )
     } catch(e) {
       throw new BuildWarning(e)
     }
@@ -375,7 +374,7 @@ class Build {
     })
 
     await promise
-    return outputLines.join('')
+    updateOutput(outputLines.join(''))
   }
 
   async _deploy() {
@@ -473,6 +472,16 @@ class Build {
     }
 
     this.info(`built ${sha} successfully`)
+
+    let { absoluteUrl } = destination
+    if (!absoluteUrl.endsWith('/')) {
+      absoluteUrl = `${absoluteUrl}/`
+    }
+
+    return {
+      outputURL: `${absoluteUrl}${evaluatedPathInDest}`,
+      localDirectory: isRemote ? null : destDir
+    }
   }
 }
 

--- a/lib/build/dispatcher.js
+++ b/lib/build/dispatcher.js
@@ -24,23 +24,43 @@ class Dispatcher {
     if (!repoConfig) {
       return
     }
+    if (payload.head_commit) {
+      // Head commit is present, branch was pushed
 
-    let { status, Build } = lookup()
-    let buildId = await status.startBuild(
-      repoConfig.url,
-      repoConfig.name,
-      repoConfig.refMode,
-      repoConfig.ref,
-      payload.head_commit.id
-    )
+      let { status, Build } = lookup()
+      let buildId = await status.startBuild(
+        repoConfig.url,
+        repoConfig.name,
+        repoConfig.refMode,
+        repoConfig.ref,
+        payload.head_commit.id
+      )
 
-    let build = new Build(buildId, payload, repoConfig)
+      let build = new Build(buildId, payload, repoConfig)
 
-    logger.debug(`enqueuing build ${buildId}`, {
-      module: `dispatcher/${repoConfig.name}`
-    })
+      logger.debug(`enqueuing build ${buildId}`, {
+        module: `dispatcher/${repoConfig.name}`
+      })
 
-    this.queue.run(() => build.build())
+      this.queue.run(() => build.build())
+    } else {
+      // No head commit, ref was removed
+
+      let { status } = lookup()
+
+      logger.debug(
+        `enqueuing cleanup job for ${repoConfig.refMode} ${repoConfig.ref}`,
+        { module: `dispatcher/${repoConfig.name}` }
+      )
+
+      this.queue.run(() =>
+        status.cleanupLocalBuilds(
+          repoConfig.name,
+          repoConfig.refMode,
+          repoConfig.ref
+        )
+      )
+    }
   }
 
   findRepository(eventType, payload) {

--- a/lib/status/status.js
+++ b/lib/status/status.js
@@ -1,5 +1,5 @@
 const { resolve } = require('path')
-const { mkdir, readdir, readFile, writeFile } = require('fs-extra')
+const { mkdir, readdir, readFile, remove, writeFile } = require('fs-extra')
 
 const { lookup, register, registerLazy } = require('../injections')
 
@@ -71,6 +71,42 @@ class Status {
     }
   }
 
+  async cleanupLocalBuilds(repoName, refMode, ref) {
+    let { logger } = this
+
+    logger.info(
+      `cleaning up local builds for ${refMode} ${ref} on ${repoName}`,
+      { module: 'status' }
+    )
+
+    let now = Date.now()
+
+    await this._updateRepoStatus(repoName, async(repoStatus) => {
+      for (let buildId in repoStatus.builds) {
+        let build = repoStatus.builds[buildId]
+        let { branch, tag, status, extra } = build
+
+        if (
+          ((refMode === 'branch' && branch === ref)
+            || (refMode === 'tag' && tag === ref))
+          && status == 'success'
+          && extra
+          && extra.localDirectory
+          && !extra.localCleaned
+        ) {
+          logger.debug(
+            `removing local build ${buildId} at ${extra.localDirectory}`,
+            { module: 'status' }
+          )
+
+          await remove(extra.localDirectory)
+          build.updated = now
+          extra.localCleaned = true
+        }
+      }
+    })
+  }
+
   async _ensureDirsExist() {
     let { statusRoot } = this
 
@@ -102,7 +138,7 @@ class Status {
         }
       }
 
-      ret = updater(repoStatus, now)
+      ret = await updater(repoStatus, now)
 
       await writeFile(statusFile, JSON.stringify(repoStatus))
     } catch(e) {
@@ -185,7 +221,10 @@ class Status {
         steps.push(step)
       }
       step.status = status
-      step.output = output
+
+      if (output) {
+        step.output = output
+      }
 
       if (status === 'success' || status === 'failed') {
         step.end = now

--- a/templates/build.hbs
+++ b/templates/build.hbs
@@ -30,7 +30,13 @@ Building SHA {{sha}} on {{branch}}{{tag}}<br>
 Enqueued at {{date enqueued}}<br>
 {{#if start}}Started at {{date start}}<br>{{/if}}
 {{#if end}}Finished at {{date end}}<br>{{/if}}
-{{#if extra.outputURL}}<a href="{{extra.outputURL}}" target="_blank">Link to deployed build output</a><br>{{/if}}
+{{#if extra.localCleaned}}
+  Build output was cleaned because {{branch}}{{tag}} was removed.<br>
+{{else}}
+  {{#if extra.outputURL}}
+    <a href="{{extra.outputURL}}" target="_blank">Link to deployed build output</a><br>
+  {{/if}}
+{{/if}}
 
 {{#each steps}}
   <h2 class="status-{{status}}">{{description}} <span class="duration">({{time duration}})</span></h2>

--- a/templates/build.hbs
+++ b/templates/build.hbs
@@ -31,7 +31,7 @@ Enqueued at {{date enqueued}}<br>
 {{#if start}}Started at {{date start}}<br>{{/if}}
 {{#if end}}Finished at {{date end}}<br>{{/if}}
 {{#if extra.localCleaned}}
-  Build output was cleaned because {{branch}}{{tag}} was removed.<br>
+  Build output was removed because {{branch}}{{tag}} was removed.<br>
 {{else}}
   {{#if extra.outputURL}}
     <a href="{{extra.outputURL}}" target="_blank">Link to deployed build output</a><br>

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -83,7 +83,9 @@
         </td>
         <td>
           {{#if extra.outputURL}}
-            <a href="{{extra.outputURL}}" target="_blank">Build output</a>
+            {{#unless extra.localCleaned}}
+              <a href="{{extra.outputURL}}" target="_blank">Build output</a>
+            {{/unless}}
           {{/if}}
         </td>
       </tr>

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -83,9 +83,11 @@
         </td>
         <td>
           {{#if extra.outputURL}}
-            {{#unless extra.localCleaned}}
+            {{#if extra.localCleaned}}
+              Removed
+            {{else}}
               <a href="{{extra.outputURL}}" target="_blank">Build output</a>
-            {{/unless}}
+            {{/if}}
           {{/if}}
         </td>
       </tr>

--- a/templates/repo.hbs
+++ b/templates/repo.hbs
@@ -81,7 +81,11 @@
       </td>
       <td>
         {{#if extra.outputURL}}
-          <a href="{{extra.outputURL}}" target="_blank">Build output</a>
+          {{#if extra.localCleaned}}
+            Removed
+          {{else}}
+            <a href="{{extra.outputURL}}" target="_blank">Build output</a>
+          {{/if}}
         {{/if}}
       </td>
     </tr>

--- a/test/unit/status/status.test.js
+++ b/test/unit/status/status.test.js
@@ -330,6 +330,43 @@ describe('unit | status/status', function() {
       ])
     })
 
+    it('updates an existing step without changing output when output is undefined', async function() {
+      let updater
+      let status = new Status()
+      status._updateRepoStatus = (_, u) => (updater = u)
+
+      await status.updateBuildStep('reponame#100', 'my step', 'some new status')
+
+      let now = Date.now()
+      let before = now - 1000
+      let build = {
+        url: 'repo/url',
+        steps: [
+          {
+            description: 'my step',
+            start: before,
+            status: 'some status',
+            output: 'some output'
+          }
+        ],
+        start: before
+      }
+      let repoStatus = {
+        nextBuildNum: 100,
+        builds: { 'reponame#100': build }
+      }
+      updater(repoStatus, now)
+
+      assert.deepEqual(build.steps, [
+        {
+          description: 'my step',
+          start: before,
+          status: 'some new status',
+          output: 'some output'
+        }
+      ])
+    })
+
     it('sets step end and duration when step status is "success"', async function() {
       let updater
       let status = new Status()


### PR DESCRIPTION
Split from #32

Closes #18 

This PR allows cleaning up local builds from removed branches.
- for local builds, we now save a `localDirectory` extra property when deploying
- when receiving a push webhook with no `head_commit` (which is what happens when a ref is removed), we search for builds with a `localDirectory` for that repo and that ref, and remove those directories. We then mark them as cleaned (with a `localCleaned` extra property)
- build status pages are updated to remove link to the output when `localCleaned` is true.

This PR also adds info in the README to help testing peon locally.

EDIT: I added some comments on the changes to better explain what we do.