### PR TITLE
feat: rework templates & build env fixes

### DIFF
--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -274,9 +274,7 @@ class Build {
             || pathInDestination.indexOf('/../') !== -1
           ) {
             throw new Error(
-              `invalid relative destination path '${
-                destination.path
-              }' (resolves to '${pathInDestination}') in .peon.yml`
+              `invalid relative destination path '${destination.path}' (resolves to '${pathInDestination}') in .peon.yml`
             )
           }
         } else {
@@ -354,7 +352,16 @@ class Build {
   async _runCommand(command, updateOutput) {
     let { workspace, env } = this
 
-    let promise = exec(command, { cwd: workspace, env: env.evaluateAll() })
+    let evaluatedEnv = env.evaluateAll()
+    let commandEnv = Object.assign({}, process.env, evaluatedEnv)
+
+    if ('NODE_ENV' in commandEnv && !('NODE_ENV' in evaluatedEnv)) {
+      // We have a NODE_ENV coming from peon environment, not from project
+      // config: remove it
+      delete commandEnv.NODE_ENV
+    }
+
+    let promise = exec(command, { cwd: workspace, env: commandEnv })
     let outputLines = []
 
     promise.childProcess.stdout.on('data', (data) => {

--- a/lib/peon.js
+++ b/lib/peon.js
@@ -38,12 +38,15 @@ class Peon {
         webhooks: { enabled: webhooksEnabled }
       },
       misc: { extractRepoName },
-      status
+      status,
+      renderer
     } = lookup()
 
     this.logger.info('Starting peon...', { module: 'peon' })
 
     await status.abortStaleBuilds()
+
+    await renderer.render(Date.now())
 
     this.watchers = []
     if (watcherEnabled) {

--- a/lib/status/render.js
+++ b/lib/status/render.js
@@ -1,16 +1,62 @@
 const { dirname, resolve } = require('path')
-const { mkdir, readdir, readFile, writeFile } = require('fs-extra')
+const { ensureDir, readdir, readFile, writeFile } = require('fs-extra')
 
 const { lookup, register, registerLazy } = require('../injections')
 
 const templateDir = resolve(dirname(dirname(__dirname)), 'templates')
-const templates = ['index', 'build']
+const templates = ['index', 'repo', 'build']
+const templateHelpers = {
+  date(timestamp) {
+    return new Date(timestamp).toISOString()
+  },
+  shortsha(sha) {
+    return sha.substr(0, 8)
+  },
+  time(milliseconds) {
+    if (typeof milliseconds !== 'number') {
+      return ''
+    }
 
-function sortBuilds(a, b) {
+    if (milliseconds < 1000) {
+      return `${milliseconds}ms`
+    } else if (milliseconds < 60000) {
+      return `${(milliseconds / 1000).toFixed(1)}s`
+    } else {
+      let seconds = Math.floor(milliseconds / 1000)
+      let min = Math.floor(seconds / 60)
+      let sec = `0${seconds % 60}`.substr(-2)
+      return `${min}m${sec}s`
+    }
+  }
+}
+
+function sortBuildIDs(a, b) {
   let [, idA] = a.split('#')
   let [, idB] = b.split('#')
 
   return Number(idA) - Number(idB)
+}
+
+function sortBuilds(a, b) {
+  return a.updated - b.updated
+}
+
+function augmentBuild(build, id, additionalInfo = {}) {
+  let [repoName, buildNum] = id.split('#')
+  return Object.assign(
+    {
+      buildId: id,
+      repoName,
+      buildNum,
+      link: `${id.replace(/#/, '/')}.html`,
+      refMode: build.branch ? 'branch' : 'tag',
+      ref: build.branch || build.tag,
+      queueTime: build.start ? build.start - build.enqueued : null,
+      runTime: build.end ? build.end - build.start : null
+    },
+    additionalInfo,
+    build
+  )
 }
 
 class Renderer {
@@ -38,9 +84,9 @@ class Renderer {
     let { Handlebars } = lookup()
 
     if (!this._initDone) {
-      Handlebars.registerHelper('date', function(timestamp) {
-        return new Date(timestamp).toISOString()
-      })
+      for (let helper in templateHelpers) {
+        Handlebars.registerHelper(helper, templateHelpers[helper])
+      }
 
       let { logger } = this
 
@@ -61,14 +107,7 @@ class Renderer {
 
   async _ensureDirsExist() {
     let { statusRoot } = this
-
-    try {
-      await mkdir(statusRoot, { recursive: true })
-    } catch(e) {
-      if (e.code !== 'EEXIST') {
-        throw e
-      }
-    }
+    await ensureDir(statusRoot)
   }
 
   async _getLastRender() {
@@ -129,27 +168,17 @@ class Renderer {
       })
 
       let [repoName, buildNum] = buildId.split('#')
+      let outputFile = resolve(statusDirectory, repoName, `${buildNum}.html`)
 
-      try {
-        await mkdir(resolve(statusDirectory, repoName), { recursive: true })
-      } catch(e) {
-        if (e.code !== 'EEXIST') {
-          throw e
-        }
-      }
+      await ensureDir(dirname(outputFile))
 
       try {
         await writeFile(
-          resolve(statusDirectory, repoName, `${buildNum}.html`),
+          outputFile,
           buildTemplate(
-            Object.assign(
-              {
-                buildId,
-                isRunning:
-                  ['pending', 'running'].indexOf(buildData.status) !== -1
-              },
-              buildData
-            )
+            augmentBuild(buildData, buildId, {
+              isRunning: ['pending', 'running'].indexOf(buildData.status) !== -1
+            })
           )
         )
       } catch(e) {
@@ -163,64 +192,69 @@ class Renderer {
     }
   }
 
-  async _renderRepo(repoStatus) {
+  async _renderRepo(now, repoName, repoStatus) {
+    let { logger, repoTemplate } = this
     let { builds } = repoStatus
-    for (let buildId in builds) {
-      await this._renderBuild(buildId, builds[buildId])
+    let {
+      config: { statusDirectory }
+    } = lookup()
+
+    let lastRender = await this._getLastRender()
+
+    if (Object.values(builds).some((b) => b.updated > lastRender)) {
+      logger.debug(`rendering repo page for ${repoName}`, {
+        module: 'status/render'
+      })
+
+      let outputFile = resolve(statusDirectory, `${repoName}.html`)
+
+      try {
+        await ensureDir(dirname(outputFile))
+        await writeFile(
+          outputFile,
+          repoTemplate({
+            now,
+            repoName,
+            builds: Object.keys(builds)
+              .sort(sortBuildIDs)
+              .reverse()
+              .map((buildId) => augmentBuild(builds[buildId], buildId))
+          })
+        )
+      } catch(e) {
+        logger.error(`error rendering ${repoName}.html`, {
+          module: 'status/render'
+        })
+        logger.error(e.stack, { module: 'status/render' })
+
+        throw e
+      }
+
+      for (let buildId in builds) {
+        await this._renderBuild(buildId, builds[buildId])
+      }
     }
   }
 
   async _renderIndex(now, reposStatus) {
-    let { logger, indexTemplate } = this
+    let { logger, indexTemplate, indexBuildCount } = this
 
     let {
       config: { statusDirectory }
     } = lookup()
 
+    let allBuilds = []
+
     for (let repo in reposStatus) {
       let repoStatus = reposStatus[repo]
       let { builds } = repoStatus
 
-      // Extract last 5 builds
-      repoStatus.lastBuilds = Object.keys(builds)
-        .sort(sortBuilds)
-        .reverse()
-        .slice(0, 5)
-        .map((buildId) =>
-          Object.assign(builds[buildId], {
-            buildId,
-            link: `${buildId.replace(/#/, '/')}.html`
+      allBuilds.push(
+        ...Object.keys(builds).map((buildId) =>
+          augmentBuild(builds[buildId], buildId, {
+            repoLink: `${repo}.html`
           })
         )
-
-      // Get all successful build IDs in reverse order
-      let successfulBuildIds = Object.keys(builds)
-        .filter((buildId) => builds[buildId].status === 'success')
-        .sort(sortBuilds)
-        .reverse()
-
-      // Get a sorted set of successfully built refs
-      let builtRefs = [
-        ...new Set(
-          successfulBuildIds.map(
-            (buildId) => builds[buildId].branch || builds[buildId].tag
-          )
-        )
-      ].sort()
-
-      // Push master to the beginning if present
-      let masterIndex = builtRefs.indexOf('master')
-      if (masterIndex) {
-        builtRefs.splice(masterIndex, 1)
-        builtRefs.unshift('master')
-      }
-
-      // Map successfully built refs to their last successful build
-      repoStatus.lastSuccessfulBuildByRef = builtRefs.map(
-        (ref) =>
-          successfulBuildIds
-            .filter((id) => builds[id].branch === ref || builds[id].tag === ref)
-            .map((id) => builds[id])[0]
       )
     }
 
@@ -230,9 +264,12 @@ class Renderer {
       await writeFile(
         resolve(statusDirectory, 'index.html'),
         indexTemplate({
-          repos: reposStatus,
           now,
-          hasData: Object.keys(reposStatus).length > 0
+          hasData: allBuilds.length > 0,
+          builds: allBuilds
+            .sort(sortBuilds)
+            .reverse()
+            .slice(0, indexBuildCount || 100)
         })
       )
     } catch(e) {
@@ -249,7 +286,7 @@ class Renderer {
     let status = await this._readReposStatus()
 
     for (let repoName in status) {
-      await this._renderRepo(status[repoName])
+      await this._renderRepo(now, repoName, status[repoName])
     }
 
     await this._renderIndex(now, status)

--- a/templates/build.hbs
+++ b/templates/build.hbs
@@ -1,9 +1,11 @@
 <title>{{buildId}} - Peon</title>
 {{#if isRunning}}
-<meta http-equiv="refresh" content="5">
+  <meta http-equiv="refresh" content="5">
 {{/if}}
 <style>
-  .status-pending, .status-running, .status-cancelled {
+  .status-pending,
+  .status-running,
+  .status-cancelled {
     background-color: #ddd;
   }
 
@@ -19,7 +21,10 @@
     background-color: #fdd;
   }
 </style>
-<h1 class="status-{{status}}">Build {{buildId}} <span class="duration">({{duration}} ms)</span></h1>
+
+<h1 class="status-{{status}}">Build {{buildId}} <span class="duration">({{time duration}})</span></h1>
+<a href="../{{repoName}}.html">View all builds for {{repoName}}</a> &ndash;
+<a href="../index.html">Peon status page</a><br><br>
 
 Building SHA {{sha}} on {{branch}}{{tag}}<br>
 Enqueued at {{date enqueued}}<br>
@@ -28,7 +33,7 @@ Enqueued at {{date enqueued}}<br>
 {{#if extra.outputURL}}<a href="{{extra.outputURL}}" target="_blank">Link to deployed build output</a><br>{{/if}}
 
 {{#each steps}}
-  <h2 class="status-{{status}}">{{description}} <span class="duration">({{duration}} ms)</span></h2>
+  <h2 class="status-{{status}}">{{description}} <span class="duration">({{time duration}})</span></h2>
   {{#if output}}
     <pre>{{output}}</pre>
   {{/if}}

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -1,7 +1,9 @@
 <title>Status page - Peon</title>
 <meta http-equiv="refresh" content="5">
 <style>
-  .status-pending, .status-running, .status-cancelled {
+  .status-pending,
+  .status-running,
+  .status-cancelled {
     background-color: #ddd;
   }
 
@@ -13,39 +15,82 @@
     background-color: #fdd;
   }
 </style>
-<h1>Peon status</h1>
+<h1>Peon status page</h1>
 
 {{#if hasData}}
-  <h2>Last successful builds</h2>
-  <ul>
-    {{#each repos as |repo repoName|}}
-      {{#if repo.lastSuccessfulBuildByRef}}
-        <li>
-          <b>{{repoName}}</b>
-          {{#each repo.lastSuccessfulBuildByRef as |build|}}
-            <a href="{{build.extra.outputURL}}" target="_blank">{{build.branch}}{{build.tag}}</a>
-          {{/each}}
-        </li>
-      {{/if}}
-    {{/each}}
-  </ul>
+  <h2>Last 100 builds</h2>
 
-  <h2>Latest builds</h2>
-  {{#each repos}}
-    <h3>{{@key}}</h3>
-    <ul>
-      {{#each lastBuilds}}
-        <li>
-          <a class="status-{{status}}" href="{{link}}">{{buildId}}</a>
-          on {{branch}}{{tag}},
-          enqueued at {{date enqueued}}
-          {{#if extra.outputURL}}<a href="{{extra.outputURL}}" target="_blank">Build output</a>{{/if}}
-        </li>
-      {{/each}}
-    </ul>
-  {{/each}}
+  <table width="100%">
+    <tr>
+      <th>
+        Repository
+      </th>
+      <th>
+        Build
+      </th>
+      <th colspan="2">
+        Ref
+      </th>
+      <th>
+        Enqueued
+      </th>
+      <th>
+        Time in queue
+      </th>
+      <th>
+        Job duration
+      </th>
+      <th>
+        Status
+      </th>
+      <th>
+        Output
+      </th>
+    </tr>
+    {{#each builds}}
+      <tr class="status-{{status}}">
+        <td>
+          <a href="{{repoLink}}">{{repoName}}</a>
+        </td>
+        <td>
+          <a href="{{link}}">{{buildNum}}</a>
+        </td>
+        <td>
+          {{refMode}}
+        </td>
+        <td>
+          {{ref}}
+        </td>
+        <td>
+          {{date enqueued}}
+        </td>
+        <td>
+          {{#if start}}
+            {{time queueTime}}
+          {{else}}
+            &ndash;
+          {{/if}}
+        </td>
+        <td>
+          {{#if end}}
+            {{time runTime}}
+          {{else}}
+            &ndash;
+          {{/if}}
+        </td>
+        <td>
+          {{status}}
+        </td>
+        <td>
+          {{#if extra.outputURL}}
+            <a href="{{extra.outputURL}}" target="_blank">Build output</a>
+          {{/if}}
+        </td>
+      </tr>
+    {{/each}}
+  </table>
 {{else}}
-  No build jobs have run yet!
+  No builds have run yet, nothing to report.
 {{/if}}
 
 <i>Last updated at {{date now}}</i>

--- a/templates/repo.hbs
+++ b/templates/repo.hbs
@@ -1,0 +1,91 @@
+<title>{{repoName}} - Peon</title>
+<meta http-equiv="refresh" content="5">
+<style>
+  .status-pending,
+  .status-running,
+  .status-cancelled {
+    background-color: #ddd;
+  }
+
+  .status-success {
+    background-color: #dfd;
+  }
+
+  .status-failed {
+    background-color: #fdd;
+  }
+</style>
+
+<h1>Peon status</h1>
+<a href="index.html">Peon status page</a>
+
+<h2>Builds for {{repoName}}</h2>
+
+<table width="100%">
+  <tr>
+    <th>
+      Build
+    </th>
+    <th colspan="3">
+      Ref
+    </th>
+    <th>
+      Enqueued
+    </th>
+    <th>
+      Time in queue
+    </th>
+    <th>
+      Job duration
+    </th>
+    <th>
+      Status
+    </th>
+    <th>
+      Output
+    </th>
+  </tr>
+  {{#each builds}}
+    <tr class="status-{{status}}">
+      <td>
+        <a href="{{link}}">{{buildNum}}</a>
+      </td>
+      <td>
+        {{refMode}}
+      </td>
+      <td>
+        {{ref}}
+      </td>
+      <td>
+        {{shortsha sha}}
+      </td>
+      <td>
+        {{date enqueued}}
+      </td>
+      <td>
+        {{#if start}}
+          {{time queueTime}}
+        {{else}}
+          &ndash;
+        {{/if}}
+      </td>
+      <td>
+        {{#if end}}
+          {{time runTime}}
+        {{else}}
+          &ndash;
+        {{/if}}
+      </td>
+      <td>
+        {{status}}
+      </td>
+      <td>
+        {{#if extra.outputURL}}
+          <a href="{{extra.outputURL}}" target="_blank">Build output</a>
+        {{/if}}
+      </td>
+    </tr>
+  {{/each}}
+</table>
+
+<i>Last updated at {{date now}}</i>

--- a/test/unit/peon.test.js
+++ b/test/unit/peon.test.js
@@ -20,6 +20,10 @@ describe('unit | peon', function() {
         }
       })
 
+      mock('renderer', {
+        async render() {}
+      })
+
       mockConfig('watcher', {
         enabled: false
       })
@@ -29,6 +33,32 @@ describe('unit | peon', function() {
       await new Peon().start()
 
       assert.ok(aborted)
+    })
+  })
+
+  describe('renderer', function() {
+    it('runs a render on startup', async function() {
+      let rendered = false
+
+      mock('status', {
+        async abortStaleBuilds() {}
+      })
+
+      mock('renderer', {
+        async render() {
+          rendered = true
+        }
+      })
+
+      mockConfig('watcher', {
+        enabled: false
+      })
+
+      mockConfig('webhooks', { enabled: false })
+
+      await new Peon().start()
+
+      assert.ok(rendered)
     })
   })
 
@@ -48,6 +78,10 @@ describe('unit | peon', function() {
           }
         }
       )
+
+      mock('renderer', {
+        async render() {}
+      })
 
       mockConfig('watcher', {
         enabled: true,
@@ -78,6 +112,10 @@ describe('unit | peon', function() {
           start() {}
         }
       )
+
+      mock('renderer', {
+        async render() {}
+      })
 
       let dispatched
       mock('dispatcher', {
@@ -121,6 +159,10 @@ describe('unit | peon', function() {
         }
       )
 
+      mock('renderer', {
+        async render() {}
+      })
+
       mockConfig('watcher', {
         enabled: false,
         repositories: [
@@ -153,6 +195,10 @@ describe('unit | peon', function() {
         }
       )
 
+      mock('renderer', {
+        async render() {}
+      })
+
       mockConfig('watcher', {
         enabled: false
       })
@@ -175,6 +221,10 @@ describe('unit | peon', function() {
           start() {}
         }
       )
+
+      mock('renderer', {
+        async render() {}
+      })
 
       let dispatched
       mock('dispatcher', {
@@ -207,6 +257,10 @@ describe('unit | peon', function() {
           }
         }
       )
+
+      mock('renderer', {
+        async render() {}
+      })
 
       mockConfig('watcher', {
         enabled: false


### PR DESCRIPTION
This PR fixes a bug where build commands are run in an incorrect environment, which makes dependencies that need building using node-gyp fail (eg. nodegit)

It also re"designs" status page templates to show builds in a table:

![image](https://user-images.githubusercontent.com/127842/68231757-ef68ae80-fffb-11e9-86d3-08ccd8dc3034.png)

It also adds a page for each repository with all builds in this repository:

![image](https://user-images.githubusercontent.com/127842/68231797-0ad3b980-fffc-11e9-9537-25d2748e3dfa.png)
