### PR TITLE
feat: use sqlite to store data (JS-159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > They do all the work behind closed doors.
 
 Peon is a minimal CD tool that can be used to run build commands on git
-repositories and deploy built artifacts locally.  The main goal is to
+repositories and deploy built artifacts locally. The main goal is to
 allow continuous deployment of static apps.
 
 It can receive Github webhooks, but when deployed on a machine that is not
@@ -34,7 +34,11 @@ A sample config file is available at the root of the project. See
 The configuration file contains the following keys:
 
 - **Base configuration:**
+
   - `workingDirectory`: a directory where peon stores its working data
+  - `dbBackupInterval`: database backup interval in milliseconds, defaults to
+    no backups.
+  - `dbBackupKeep`: number of previous backups to keep, defaults to keeping all.
   - `cacheValidity`: validity in milliseconds of paths cached during builds.
   - `cacheMaxSize`: maximum size of cache in bytes; peon will remove the oldest
     non-expired cache items until cache size is below that limit. Set to 0 for
@@ -42,11 +46,14 @@ The configuration file contains the following keys:
   - `statusDirectory`: a directory where peon will store its status pages.
   - `statusUrl`: URL where the status directory is served (used for github
     build status updates)
+  - `indexBuildCount`: maximum number of builds to show on status index page,
+    defaults to all builds
   - `githubAPIToken`: a GitHub API token used to update build status on commits.
 
 - **Watcher configuration:** enable this when you want peon to poll git
   repositories at regular intervals (useful when the machine is not reachable
   from the internet and thus cannot receive webhooks)
+
   - `watcher.enabled`: boolean, enables or disables repository watchers
   - `watcher.interval`: interval in milliseconds between polls on each
     repository
@@ -56,6 +63,7 @@ The configuration file contains the following keys:
 
 - **Webhooks configuration:** enable this when the machine is reachable from the
   internet to listen for Github webhooks
+
   - `webhooks.enabled`: boolean, enables or disables listening for webhooks
   - `webhooks.port`: port to listen on; Peon will only listen on localhost so
     you must have a web server running that proxies webhook requests received
@@ -64,22 +72,24 @@ The configuration file contains the following keys:
     your repositories on Github.
 
 - **Build output destinations configuration:** configure destinations where Peon
-  will store build outputs (using rsync).  Destinations can be local or remote.
+  will store build outputs (using rsync). Destinations can be local or remote.
+
   - `destinations.$name.destination`: local or remote path specification, for
-    example `/var/www/peon` or `[user@]host:/path/to/directory`.  The directory
+    example `/var/www/peon` or `[user@]host:/path/to/directory`. The directory
     must exist.
-  - `destinations.$name.rootUrl`: root URL path  the destination is served by a
+  - `destinations.$name.rootUrl`: root URL path the destination is served by a
     webserver (without the protocol/host/port).
   - `destinations.$name.absoluteUrl`: full URL the destination is served by a
-    webserver (**with** protocol/host/port).  This is used so that peon can
+    webserver (**with** protocol/host/port). This is used so that peon can
     generate links to the deployed build.
   - `destinations.$name.shell`: used only for remote destinations; shell command
-    to use to connect to the remote.  You can use it to pass SSH options (for
-    example `ssh -o StrictHostKeyChecking=no -i /path/to/id_rsa`).  Note that
+    to use to connect to the remote. You can use it to pass SSH options (for
+    example `ssh -o StrictHostKeyChecking=no -i /path/to/id_rsa`). Note that
     the command will run as the same user Peon is running as.
 
 - **Git auth configuration:** set up which auth method to use to clone private
   repositories
+
   - `git.authMethod`: `agent` to use the SSH agent for the user running Peon,
     `key` to use a PEM-format key pair
   - `git.privateKey`: path to the private key to use
@@ -91,23 +101,24 @@ The configuration file contains the following keys:
   - `logger.level`: one of `error`, `info`, `debug`.
 
 **Notes:**
+
 - The user running peon must have writing rights on `workingDirectory` and
   `statusDirectory`.
 - Do not watch a repository that also emits webhooks, it will conflict.
 
 ### Running Peon
 
-Run `node ./index.js` from the repostory root.  You may want to use some
+Run `node ./index.js` from the repostory root. You may want to use some
 kind of process manager (forever, pm2, systemd...) to keep it running.
 
 ## Repository configuration
 
 Peon will only run builds when it finds a `.peon.yml` file at the root of a
-repository.  A reference of available options follows.
+repository. A reference of available options follows.
 
 ### `branches` (optional) - branches allowed to build
 
-By default Peon triggers builds on all branches.  To restrict branches that can
+By default Peon triggers builds on all branches. To restrict branches that can
 trigger a build, you can specify them as a list of regexps.
 
 ```yaml
@@ -119,7 +130,7 @@ branches:
 ### `cache` (optional) - build assets caching
 
 Peon allows storing build assets in cache after a build an restoring them before
-a subsequent build.  This is useful for example when one of the building steps
+a subsequent build. This is useful for example when one of the building steps
 downloads dependencies based on a requirements file (eg. npm, yarn, pip) and you
 don't want the whole process of downloading all the dependencies to run again
 when your project hasn't changed.
@@ -144,14 +155,15 @@ commands:
 ```
 
 The following environment variables are available to those commands:
-* `$PEON_BUILD_ID`: ID of the build (eg. "reponame#123")
-* `$PEON_BUILD_DATE`: ISO-formatted timestamp of the build start date
-* `$PEON_REPO_NAME`: name of the repository being built
-* `$PEON_BRANCH`: branch being built if building a branch
-* `$PEON_TAG`: tag being built if building a tag
-* `$PEON_REF`: equivalent to `$PEON_BRANCH` or `$PEON_TAG`
-* `$PEON_COMMIT`: commit SHA1 being built
-* `$PEON_ROOT_URL`: root URL where the build will be served,
+
+- `$PEON_BUILD_ID`: ID of the build (eg. "reponame#123")
+- `$PEON_BUILD_DATE`: ISO-formatted timestamp of the build start date
+- `$PEON_REPO_NAME`: name of the repository being built
+- `$PEON_BRANCH`: branch being built if building a branch
+- `$PEON_TAG`: tag being built if building a tag
+- `$PEON_REF`: equivalent to `$PEON_BRANCH` or `$PEON_TAG`
+- `$PEON_COMMIT`: commit SHA1 being built
+- `$PEON_ROOT_URL`: root URL where the build will be served,
 
 Additional environment variables may be specified in the repository
 configuration file, see `environment` below.
@@ -160,12 +172,12 @@ configuration file, see `environment` below.
 
 Peon configuration file allows defining a list of named destinations to deploy
 build outputs, both local (on the machine where Peon is running) and remote
-(using rsync).  From the perspective of your project however, there is no
+(using rsync). From the perspective of your project however, there is no
 difference between local and remote destinations.
 
 The `destinations` key in the repository configuration file specifies which
 destination(s) you want to use when deploying your project and which branches or
-tags they apply to.  Peon will use the first matching destination, and will
+tags they apply to. Peon will use the first matching destination, and will
 abort the build when no destination matches.
 
 ```yaml
@@ -188,27 +200,29 @@ destinations:
 ```
 
 Each destination you specify has the following keys:
-* `name`: mandatory; name of a destination defined in Peon configuration file
-* `path`: optional; path relative to the destination to store the build into.
-  If not specified, defaults to `$PEON_REPO_NAME/$PEON_REF`.  You can use peon
+
+- `name`: mandatory; name of a destination defined in Peon configuration file
+- `path`: optional; path relative to the destination to store the build into.
+  If not specified, defaults to `$PEON_REPO_NAME/$PEON_REF`. You can use peon
   environment variables in the value.
-* `branch`: optional, ignored when building a tag; regexp checked against the
+- `branch`: optional, ignored when building a tag; regexp checked against the
   branch being built. If not specified, defaults to matching all branches,
-  unless a tag regexp is also specified in which case it defaults to *not*
+  unless a tag regexp is also specified in which case it defaults to _not_
   matching any branch.
-* `tag`: optional, ignored when building a branch; regexp checked against the
-  tag being built, defaults to *not* matching any tag.
+- `tag`: optional, ignored when building a branch; regexp checked against the
+  tag being built, defaults to _not_ matching any tag.
 
 To summarize the destination choice process:
-* When building a branch, Peon will chose the first destination that either has
+
+- When building a branch, Peon will chose the first destination that either has
   a matching `branch` regexp or has neither a `branch` nor a `tag` regexp.
-* When building a tag, Peon will chose the first destination that explicitly
+- When building a tag, Peon will chose the first destination that explicitly
   defines a matching `tag` regexp.
 
 ### `environment` (optional) - additional build environment variables
 
 You can specify additional environment variables that will be made available to
-all build commands.  Values can include Peon environment variables.
+all build commands. Values can include Peon environment variables.
 
 ```yaml
 environment:
@@ -219,7 +233,7 @@ environment:
 ### `output` (mandatory) - where to find the build output
 
 This should be the name of a directory relative to the repository root where
-Peon can find the build output.  Its contents will be copied into the directory
+Peon can find the build output. Its contents will be copied into the directory
 specified in the `destinations` configuration.
 
 ```yaml
@@ -228,7 +242,7 @@ output: dist
 
 ### `tags` (optional) - tags allowed to build
 
-By default Peon does not trigger any build on tags.  If you want to trigger
+By default Peon does not trigger any build on tags. If you want to trigger
 builds when pushing tags, you can specify a list of tag regexps.
 
 ```yaml
@@ -236,7 +250,7 @@ tags:
   - ^v\d+\.\d+\.\d+$
 ```
 
-*Note:* you can only trigger builds on tags from webhooks, not from the watcher.
+_Note:_ you can only trigger builds on tags from webhooks, not from the watcher.
 
 # License
 

--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -147,6 +147,7 @@ class Build {
         return
       } else {
         this.error(`error during step '${stepName}'`)
+        this.error(e.stack)
         await updateStep('failed', e.message)
         throw e
       }
@@ -298,7 +299,7 @@ class Build {
     this.env = new Environment(
       Object.assign(
         {
-          PEON_BUILD_ID: buildId,
+          PEON_BUILD_ID: `${buildId}`,
           PEON_BUILD_DATE: start.toISOString(),
           PEON_ROOT_URL: join(matchingDestination.rootUrl, pathInDestination),
           PEON_REPO_NAME: repoName,

--- a/lib/build/cache.js
+++ b/lib/build/cache.js
@@ -1,7 +1,7 @@
 const { createHash } = require('crypto')
 const { access, mkdir, readdir, readFile, stat, unlink } = require('fs-extra')
 const { resolve } = require('path')
-const { lookup, register, registerLazy } = require('../injections')
+const { lookup, registerForTest, registerLazy } = require('../injections')
 
 class Cache {
   get logger() {
@@ -201,5 +201,5 @@ class Cache {
   }
 }
 
-register(Cache)
+registerForTest(Cache)
 registerLazy('cache', () => new Cache())

--- a/lib/build/dispatcher.js
+++ b/lib/build/dispatcher.js
@@ -1,4 +1,4 @@
-const { lookup, register, registerLazy } = require('../injections')
+const { lookup, registerForTest, registerLazy } = require('../injections')
 
 class Dispatcher {
   get logger() {
@@ -109,5 +109,5 @@ class Dispatcher {
   }
 }
 
-register(Dispatcher)
+registerForTest(Dispatcher)
 registerLazy('dispatcher', () => new Dispatcher())

--- a/lib/injections.js
+++ b/lib/injections.js
@@ -12,6 +12,11 @@
 
 const registry = {}
 const lazies = {}
+let testing = false
+
+function testMode(mode) {
+  testing = mode
+}
 
 function registerLazy(key, initializer) {
   delete lazies[key]
@@ -35,8 +40,16 @@ function register(key, value) {
   registerLazy(key, () => value)
 }
 
+function registerForTest() {
+  if (!testing) {
+    return
+  }
+
+  register(...arguments)
+}
+
 function lookup(key) {
   return key ? registry[key] : registry
 }
 
-module.exports = { register, registerLazy, lookup }
+module.exports = { register, registerForTest, registerLazy, lookup, testMode }

--- a/lib/peon.js
+++ b/lib/peon.js
@@ -1,12 +1,14 @@
 /* eslint-disable camelcase */
 
 const requireDirectory = require('require-directory')
-const { lookup, register } = require('./injections')
+const { lookup, register, testMode } = require('./injections')
 
 const moduleDirs = ['build', 'status', 'utils', 'watch']
 
 class Peon {
-  static loadModules() {
+  static loadModules(testing = false) {
+    testMode(testing)
+
     // Register external modules so they can be mocked
     register('Git', require('nodegit'))
     register('Handlebars', require('handlebars'))
@@ -39,14 +41,15 @@ class Peon {
       },
       misc: { extractRepoName },
       status,
-      renderer
+      renderer,
+      db
     } = lookup()
 
     this.logger.info('Starting peon...', { module: 'peon' })
 
+    await db.importJSONFiles()
     await status.abortStaleBuilds()
-
-    await renderer.render(Date.now())
+    await renderer.render()
 
     this.watchers = []
     if (watcherEnabled) {

--- a/lib/status/db.js
+++ b/lib/status/db.js
@@ -1,0 +1,375 @@
+const { copy, ensureDir, move, readdir, readFile, unlink } = require('fs-extra')
+const { dirname, resolve } = require('path')
+const sqlite = require('sqlite')
+const SQL = require('sql-template-strings')
+const { lookup, registerForTest, registerLazy } = require('../injections')
+
+const migrationsDir = resolve(__dirname, 'migrations')
+
+function parseExtra(build) {
+  if (build.extra) {
+    build.extra = JSON.parse(build.extra)
+  }
+
+  return build
+}
+
+class Database {
+  get logger() {
+    if (!this._logger) {
+      let { getLogger } = lookup()
+      this._logger = getLogger('db')
+    }
+    return this._logger
+  }
+
+  get dbFile() {
+    let {
+      config: { workingDirectory }
+    } = lookup()
+
+    if (!workingDirectory) {
+      throw new Error('Cannot open database, no workingDirectory set')
+    }
+
+    return resolve(workingDirectory, 'peon.sqlite')
+  }
+
+  get db() {
+    if (!this.dbPromise) {
+      let {
+        config: { dbBackupInterval }
+      } = lookup()
+
+      this.dbPromise = (async() => {
+        let { dbFile } = this
+
+        await ensureDir(dirname(dbFile))
+
+        this.logger.debug('Opening database', { module: 'db' })
+        let db = await sqlite.open(dbFile, {
+          Promise,
+          cached: true
+        })
+
+        this.logger.debug('Running migrations', { module: 'db' })
+        await db.migrate({ migrationsPath: migrationsDir })
+
+        this.logger.info('Database is open', { module: 'db' })
+        return db
+      })()
+
+      if (dbBackupInterval && !this.backupInterval) {
+        this.backupInterval = setInterval(
+          () => this._backup(),
+          dbBackupInterval
+        )
+      }
+    }
+
+    return this.dbPromise
+  }
+
+  async close() {
+    if (this.dbPromise) {
+      let db = await this.db
+      this.dbPromise = null
+
+      await db.close()
+      clearInterval(this.backupInterval)
+
+      this.logger.debug('Database is closed', { module: 'db' })
+    }
+  }
+
+  async _backup() {
+    let {
+      config: { dbBackupKeep, workingDirectory }
+    } = lookup()
+
+    let { dbFile } = this
+    let backupFile = `${dbFile}.${new Date().toISOString().replace(/:/g, '-')}`
+
+    this.logger.debug(`Creating backup ${backupFile}`, { module: 'db' })
+    await copy(dbFile, backupFile)
+
+    if (dbBackupKeep) {
+      let staleBackups = (await readdir(dirname(dbFile)))
+        .filter((f) => f.match(/^peon\.sqlite\./))
+        .sort()
+        .reverse()
+        .slice(dbBackupKeep)
+
+      for (let stale of staleBackups) {
+        this.logger.debug(`Removing stale backup ${stale}`, { module: 'db' })
+        await unlink(resolve(workingDirectory, stale))
+      }
+    }
+  }
+
+  async _runQuery(method, query) {
+    let db = await this.db
+
+    try {
+      return await db[method](query)
+    } catch(e) {
+      let descr
+
+      if (typeof query !== 'string') {
+        descr = `"${query.text}"`
+
+        if (query.values.length) {
+          descr = `${descr} with values ${query.values
+            .map((v) => `"${v}"`)
+            .join(', ')}`
+        }
+      } else {
+        descr = `"${query}"`
+      }
+
+      this.logger.error(`error running query ${descr}`)
+      this.logger.error(e.stack)
+
+      throw e
+    }
+  }
+
+  _all(query) {
+    return this._runQuery('all', query)
+  }
+
+  _get(query) {
+    return this._runQuery('get', query)
+  }
+
+  _run(query) {
+    return this._runQuery('run', query)
+  }
+
+  async importJSONFiles() {
+    let {
+      config: { workingDirectory }
+    } = lookup()
+
+    let statusRoot = resolve(workingDirectory, 'status')
+
+    await ensureDir(statusRoot)
+
+    for (let file of await readdir(statusRoot)) {
+      if (!file.endsWith('.json')) {
+        continue
+      }
+
+      if (file !== 'peon-status.json') {
+        this.logger.debug(`Importing data from ${file}`, { module: 'db' })
+
+        let repoName = file.replace('.json', '')
+        let projectStatus = JSON.parse(
+          await readFile(resolve(statusRoot, file))
+        )
+
+        let repo = await this._get(
+          SQL`SELECT id, name, url FROM Repo WHERE name = ${repoName}`
+        )
+
+        for (let oldBuildID in projectStatus.builds) {
+          let build = projectStatus.builds[oldBuildID]
+
+          if (!repo) {
+            let { lastID: repoId } = await this._run(
+              SQL`INSERT INTO Repo(name, url) VALUES(${repoName}, ${build.url})`
+            )
+
+            repo = await this._get(
+              SQL`SELECT id, name, url FROM Repo WHERE id = ${repoId}`
+            )
+          }
+
+          let {
+            branch,
+            tag,
+            sha,
+            enqueued,
+            updated,
+            start,
+            end,
+            status,
+            steps,
+            extra
+          } = build
+
+          let refMode = branch ? 'branch' : 'tag'
+          let ref = branch || tag
+
+          let extraJson = JSON.stringify(
+            Object.assign({ oldBuildID }, extra || {})
+          )
+
+          let { lastID: buildId } = await this._run(
+            SQL`INSERT INTO Build(repo_id, ref_type, ref, sha, enqueued,
+                                  updated, start, end, status, extra)
+                VALUES(${repo.id}, ${refMode}, ${ref}, ${sha}, ${enqueued},
+                       ${updated}, ${start}, ${end}, ${status}, ${extraJson})`
+          )
+
+          for (let step of steps) {
+            let { description, start, status, output, end } = step
+            await this._run(
+              SQL`INSERT INTO Step(build_id, description, start, end, status,
+                                   output)
+                  VALUES(${buildId}, ${description}, ${start}, ${end},
+                         ${status}, ${output})`
+            )
+          }
+        }
+
+        this.logger.debug(
+          `Imported ${Object.keys(projectStatus.builds).length} builds`,
+          { module: 'db' }
+        )
+
+        await move(
+          resolve(statusRoot, file),
+          resolve(statusRoot, `${file}.imported`)
+        )
+      }
+    }
+  }
+
+  async getRepos() {
+    return await this._all(SQL`SELECT id, name, url FROM Repo`)
+  }
+
+  async getOrCreateRepo({ name, url }) {
+    let repo = await this._get(
+      SQL`SELECT id, name, url FROM Repo WHERE name = ${name}`
+    )
+
+    if (!repo) {
+      let { lastID } = await this._run(
+        SQL`INSERT INTO Repo(name, url) VALUES(${name}, ${url})`
+      )
+
+      repo = await this._get(
+        SQL`SELECT id, name, url FROM Repo WHERE id = ${lastID}`
+      )
+    }
+
+    return repo
+  }
+
+  async getBuilds(repoId) {
+    return (await this._all(
+      SQL`SELECT b.id, b.ref_type, b.ref, b.sha, b.enqueued, b.updated, b.start,
+                 b.end, b.status, b.extra
+          FROM Build b
+          WHERE b.repo_id = ${repoId}
+          ORDER BY b.updated DESC`
+    )).map(parseExtra)
+  }
+
+  async getStaleBuilds() {
+    return await this._all(
+      SQL`SELECT id FROM Build
+          WHERE status IN ('pending', 'running')`
+    )
+  }
+
+  async getLastUpdatedBuilds(count) {
+    let query = SQL`SELECT r.name as repo_name, r.url as repo_url, b.id,
+                           b.repo_id, b.ref_type, b.ref, b.sha, b.enqueued,
+                           b.updated, b.start, b.end, b.status
+                    FROM Build b JOIN Repo r ON r.id = b.repo_id
+                    ORDER BY b.updated DESC`
+
+    return (await this._all(count ? query.append(SQL` LIMIT ${count}`) : query)).map(parseExtra)
+  }
+
+  async createBuild({ repoId, refMode, ref, sha }) {
+    let now = Date.now()
+
+    let { lastID } = await this._run(
+      SQL`INSERT INTO Build(repo_id, ref_type, ref, sha, enqueued, updated,
+                            status)
+          VALUES(${repoId}, ${refMode}, ${ref}, ${sha}, ${now}, ${now},
+                 'pending')`
+    )
+
+    return lastID
+  }
+
+  async updateBuild({ id, status, extra }) {
+    let now = Date.now()
+
+    let build = await this._get(
+      SQL`SELECT status, start FROM Build WHERE id = ${id}`
+    )
+
+    let query = SQL`UPDATE Build SET status = ${status}, updated = ${now}`
+
+    if (!build.start && status !== 'cancelled' && status !== 'failed') {
+      query.append(SQL`, start = ${now}`)
+    }
+
+    if (status === 'failed' || status === 'success') {
+      query.append(SQL`, end = ${now}`)
+    }
+
+    if (extra) {
+      query.append(SQL`, extra = ${JSON.stringify(extra)}`)
+    }
+
+    await this._run(query.append(SQL` WHERE id = ${id}`))
+  }
+
+  async getSteps(buildId) {
+    return this._all(
+      SQL`SELECT id, description, start, end, status, output
+          FROM Step WHERE build_id = ${buildId}
+          ORDER BY start`
+    )
+  }
+
+  async updateStep({ buildId, description, status, output }) {
+    let now = Date.now()
+
+    await this.updateBuild({ id: buildId, status: 'running' })
+
+    let step = await this._get(
+      SQL`SELECT id FROM Step
+          WHERE build_id = ${buildId} AND description = ${description}`
+    )
+
+    if (!step) {
+      let { lastID } = await this._run(
+        SQL`INSERT INTO Step(build_id, description, start, status)
+            VALUES(${buildId}, ${description}, ${now}, ${status})`
+      )
+
+      step = { id: lastID }
+    }
+
+    let query = SQL`UPDATE Step SET status = ${status}`
+
+    if (status === 'success' || status === 'failed') {
+      query.append(SQL`, end = ${now}`)
+    }
+
+    if (output) {
+      query.append(SQL`, output = ${output}`)
+    }
+
+    await this._run(query.append(SQL` WHERE id = ${step.id}`))
+  }
+
+  async getGitBuildInfo(buildId) {
+    return await this._get(
+      SQL`SELECT b.sha, r.url
+          FROM Build b JOIN Repo r ON r.id = b.repo_id
+          WHERE b.id = ${buildId}`
+    )
+  }
+}
+
+registerForTest(Database)
+registerLazy('db', () => new Database())

--- a/lib/status/github.js
+++ b/lib/status/github.js
@@ -1,4 +1,4 @@
-const { lookup, register, registerLazy } = require('../injections')
+const { lookup, registerForTest, registerLazy } = require('../injections')
 
 class GithubStatus {
   get api() {
@@ -32,12 +32,15 @@ class GithubStatus {
     return this._queue
   }
 
-  update(repoUrl, buildId, sha, state, description) {
+  async update(buildId, state, description) {
     let { api, queue } = this
     let {
       misc: { extractGithubRepo },
-      config: { statusUrl }
+      config: { statusUrl },
+      db
     } = lookup()
+
+    let { sha, url: repoUrl } = await db.getGitBuildInfo(buildId)
     let githubRepo = extractGithubRepo(repoUrl)
 
     if (!githubRepo || !api) {
@@ -54,7 +57,7 @@ class GithubStatus {
           // eslint-disable-next-line camelcase
           target_url: `${statusUrl}${
             statusUrl.endsWith('/') ? '' : '/'
-          }${buildId.replace(/#/, '/')}.html`,
+          }${buildId}.html`,
           context: 'peon',
           description
         })
@@ -68,5 +71,5 @@ class GithubStatus {
   }
 }
 
-register(GithubStatus)
+registerForTest(GithubStatus)
 registerLazy('githubStatus', () => new GithubStatus())

--- a/lib/status/migrations/001_initial.sql
+++ b/lib/status/migrations/001_initial.sql
@@ -1,0 +1,49 @@
+--------------------------------------------------------------------------------
+-- Up
+--------------------------------------------------------------------------------
+
+CREATE TABLE "Repo" (
+  "id" INTEGER PRIMARY KEY,
+  "name" TEXT NOT NULL,
+  "url" TEXT NOT NULL
+);
+
+CREATE TABLE "Build" (
+  "id" INTEGER PRIMARY KEY,
+  "repo_id" INTEGER NOT NULL,
+  "ref_type" TEXT NOT NULL,
+  "ref" TEXT NOT NULL,
+  "sha" TEXT NOT NULL,
+  "enqueued" INTEGER NOT NULL,
+  "updated" INTEGER NOT NULL,
+  "start" INTEGER,
+  "end" INTEGER,
+  "status" TEXT NOT NULL,
+  "extra" TEXT,
+
+  CONSTRAINT "Build_fk_repo_id"
+    FOREIGN KEY("repo_id") REFERENCES "Repo"("id")
+    ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE "Step" (
+  "id" INTEGER PRIMARY KEY,
+  "build_id" INTEGER NOT NULL,
+  "description" TEXT NOT NULL,
+  "start" INTEGER NOT NULL,
+  "end" INTEGER,
+  "status" TEXT NOT NULL,
+  "output" TEXT,
+
+  CONSTRAINT "Step_fk_build_id"
+    FOREIGN KEY("build_id") REFERENCES "Build"("id")
+    ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+--------------------------------------------------------------------------------
+-- Down
+--------------------------------------------------------------------------------
+
+DROP TABLE "Step";
+DROP TABLE "Build";
+DROP TABLE "Repo";

--- a/lib/status/migrations/002_indices.sql
+++ b/lib/status/migrations/002_indices.sql
@@ -1,0 +1,17 @@
+--------------------------------------------------------------------------------
+-- Up
+--------------------------------------------------------------------------------
+
+CREATE INDEX "Repo_ix_name" ON "Repo"("name");
+CREATE INDEX "Build_ix_repo_id" ON "Build"("repo_id");
+CREATE INDEX "Build_ix_status" ON "Build"("status");
+CREATE INDEX "Step_ix_build_id_description" ON "Step"("build_id", "description");
+
+--------------------------------------------------------------------------------
+-- Down
+--------------------------------------------------------------------------------
+
+DROP INDEX "Step_ix_build_id_description";
+DROP INDEX "Build_ix_status";
+DROP INDEX "Build_ix_repo_id";
+DROP INDEX "Repo_ix_name";

--- a/lib/status/render.js
+++ b/lib/status/render.js
@@ -7,7 +7,7 @@ const { lookup, registerForTest, registerLazy } = require('../injections')
 
 const templateDir = resolve(dirname(dirname(__dirname)), 'templates')
 
-const templates = ['index', 'repo', 'build']
+const templates = ['index', 'repo', 'build', 'buildredir']
 
 const templateHelpers = {
   date(timestamp) {
@@ -101,7 +101,7 @@ class Renderer {
   }
 
   async _renderBuild(repo, build) {
-    let { logger, buildTemplate } = this
+    let { logger, buildTemplate, buildredirTemplate } = this
 
     let {
       config: { statusDirectory },
@@ -131,6 +131,24 @@ class Renderer {
       logger.error(e.stack, { module: 'status/render' })
 
       throw e
+    }
+
+    if (build.extra && build.extra.oldBuildID) {
+      let { id, extra: { oldBuildID } } = build
+
+      let redirectFile = resolve(statusDirectory, `${oldBuildID.replace(/#/g, '/')}.html`)
+
+      try {
+        await ensureDir(dirname(redirectFile))
+        await writeFile(redirectFile, buildredirTemplate({ id }))
+      } catch(e) {
+        logger.error('error rendering old build redirection file', {
+          module: 'status/render'
+        })
+        logger.error(e.stack, { module: 'status/render' })
+
+        throw e
+      }
     }
   }
 

--- a/lib/status/render.js
+++ b/lib/status/render.js
@@ -1,10 +1,14 @@
-const { dirname, resolve } = require('path')
-const { ensureDir, readdir, readFile, writeFile } = require('fs-extra')
+/* eslint-disable camelcase */
 
-const { lookup, register, registerLazy } = require('../injections')
+const { dirname, resolve } = require('path')
+const { ensureDir, readFile, writeFile } = require('fs-extra')
+
+const { lookup, registerForTest, registerLazy } = require('../injections')
 
 const templateDir = resolve(dirname(dirname(__dirname)), 'templates')
+
 const templates = ['index', 'repo', 'build']
+
 const templateHelpers = {
   date(timestamp) {
     return new Date(timestamp).toISOString()
@@ -30,36 +34,34 @@ const templateHelpers = {
   }
 }
 
-function sortBuildIDs(a, b) {
-  let [, idA] = a.split('#')
-  let [, idB] = b.split('#')
-
-  return Number(idA) - Number(idB)
-}
-
-function sortBuilds(a, b) {
-  return a.updated - b.updated
-}
-
-function augmentBuild(build, id, additionalInfo = {}) {
-  let [repoName, buildNum] = id.split('#')
+function augmentBuild(build, additionalInfo = {}) {
   return Object.assign(
+    build.repo_name ? { repo_link: `${build.repo_name}.html` } : {},
     {
-      buildId: id,
-      repoName,
-      buildNum,
-      link: `${id.replace(/#/, '/')}.html`,
-      refMode: build.branch ? 'branch' : 'tag',
-      ref: build.branch || build.tag,
-      queueTime: build.start ? build.start - build.enqueued : null,
-      runTime: build.end ? build.end - build.start : null
+      build_link: `${build.id}.html`,
+      queue_time: build.start ? build.start - build.enqueued : null,
+      run_time: build.end ? build.end - build.start : null
     },
     additionalInfo,
     build
   )
 }
 
+function augmentStep(step, additionalInfo = {}) {
+  return Object.assign(
+    {
+      duration: step.end ? step.end - step.start : null
+    },
+    additionalInfo,
+    step
+  )
+}
+
 class Renderer {
+  constructor() {
+    this.lastRender = 0
+  }
+
   get logger() {
     if (!this._logger) {
       let { getLogger } = lookup()
@@ -68,22 +70,15 @@ class Renderer {
     return this._logger
   }
 
-  get statusRoot() {
+  async _init() {
     let {
-      config: { workingDirectory }
+      Handlebars,
+      config: { statusDirectory }
     } = lookup()
-    return resolve(workingDirectory, 'status')
-  }
-
-  get renderInfoFile() {
-    let { statusRoot } = this
-    return resolve(statusRoot, 'peon-status.json')
-  }
-
-  async init() {
-    let { Handlebars } = lookup()
 
     if (!this._initDone) {
+      await ensureDir(statusDirectory)
+
       for (let helper in templateHelpers) {
         Handlebars.registerHelper(helper, templateHelpers[helper])
       }
@@ -105,196 +100,161 @@ class Renderer {
     this._initDone = true
   }
 
-  async _ensureDirsExist() {
-    let { statusRoot } = this
-    await ensureDir(statusRoot)
-  }
-
-  async _getLastRender() {
-    let { renderInfoFile, lastRender } = this
-
-    if (typeof lastRender === 'undefined') {
-      await this._ensureDirsExist()
-
-      try {
-        this.lastRender = JSON.parse(await readFile(renderInfoFile)).lastRender
-      } catch(e) {
-        this.lastRender = 0
-      }
-    }
-
-    return this.lastRender
-  }
-
-  async _setLastRender(now) {
-    let { renderInfoFile } = this
-
-    this.lastRender = now
-
-    await this._ensureDirsExist()
-    await writeFile(renderInfoFile, JSON.stringify({ lastRender: now }))
-  }
-
-  async _readReposStatus() {
-    let { statusRoot } = this
-    let status = {}
-
-    await this._ensureDirsExist()
-    for (let file of await readdir(statusRoot)) {
-      if (file === 'peon-status.json') {
-        continue
-      }
-
-      status[file.replace(/\.json$/, '')] = JSON.parse(
-        await readFile(resolve(statusRoot, file))
-      )
-    }
-
-    return status
-  }
-
-  async _renderBuild(buildId, buildData) {
+  async _renderBuild(repo, build) {
     let { logger, buildTemplate } = this
 
     let {
-      config: { statusDirectory }
+      config: { statusDirectory },
+      db
     } = lookup()
 
-    let lastRender = await this._getLastRender()
+    logger.debug(`rendering build ${build.id}`, {
+      module: 'status/render'
+    })
 
-    if (buildData.updated > lastRender) {
-      logger.debug(`rendering build ${buildId}`, {
-        module: 'status/render'
-      })
+    let steps = await db.getSteps(build.id)
+    let outputFile = resolve(statusDirectory, `${build.id}.html`)
 
-      let [repoName, buildNum] = buildId.split('#')
-      let outputFile = resolve(statusDirectory, repoName, `${buildNum}.html`)
+    let buildData = augmentBuild(build, {
+      repo_link: `${repo.name}.html`,
+      repo_name: repo.name,
+      steps: steps.map((s) => augmentStep(s)),
+      is_running: ['pending', 'running'].indexOf(build.status) !== -1
+    })
 
-      await ensureDir(dirname(outputFile))
-
-      try {
-        await writeFile(
-          outputFile,
-          buildTemplate(
-            augmentBuild(buildData, buildId, {
-              isRunning: ['pending', 'running'].indexOf(buildData.status) !== -1
-            })
-          )
-        )
-      } catch(e) {
-        logger.error(`error rendering ${repoName}/${buildNum}.html`, {
-          module: 'status/render'
-        })
-        logger.error(e.stack, { module: 'status/render' })
-
-        throw e
-      }
-    }
-  }
-
-  async _renderRepo(now, repoName, repoStatus) {
-    let { logger, repoTemplate } = this
-    let { builds } = repoStatus
-    let {
-      config: { statusDirectory }
-    } = lookup()
-
-    let lastRender = await this._getLastRender()
-
-    if (Object.values(builds).some((b) => b.updated > lastRender)) {
-      logger.debug(`rendering repo page for ${repoName}`, {
-        module: 'status/render'
-      })
-
-      let outputFile = resolve(statusDirectory, `${repoName}.html`)
-
-      try {
-        await ensureDir(dirname(outputFile))
-        await writeFile(
-          outputFile,
-          repoTemplate({
-            now,
-            repoName,
-            builds: Object.keys(builds)
-              .sort(sortBuildIDs)
-              .reverse()
-              .map((buildId) => augmentBuild(builds[buildId], buildId))
-          })
-        )
-      } catch(e) {
-        logger.error(`error rendering ${repoName}.html`, {
-          module: 'status/render'
-        })
-        logger.error(e.stack, { module: 'status/render' })
-
-        throw e
-      }
-
-      for (let buildId in builds) {
-        await this._renderBuild(buildId, builds[buildId])
-      }
-    }
-  }
-
-  async _renderIndex(now, reposStatus) {
-    let { logger, indexTemplate, indexBuildCount } = this
-
-    let {
-      config: { statusDirectory }
-    } = lookup()
-
-    let allBuilds = []
-
-    for (let repo in reposStatus) {
-      let repoStatus = reposStatus[repo]
-      let { builds } = repoStatus
-
-      allBuilds.push(
-        ...Object.keys(builds).map((buildId) =>
-          augmentBuild(builds[buildId], buildId, {
-            repoLink: `${repo}.html`
-          })
-        )
-      )
-    }
-
-    // Render index
-    logger.debug('rendering index', { module: 'status/render' })
     try {
-      await writeFile(
-        resolve(statusDirectory, 'index.html'),
-        indexTemplate({
-          now,
-          hasData: allBuilds.length > 0,
-          builds: allBuilds
-            .sort(sortBuilds)
-            .reverse()
-            .slice(0, indexBuildCount || 100)
-        })
-      )
+      await writeFile(outputFile, buildTemplate(buildData))
     } catch(e) {
-      logger.error('error rendering index', { module: 'status/render' })
+      logger.error(`error rendering ${build.id}.html`, {
+        module: 'status/render'
+      })
       logger.error(e.stack, { module: 'status/render' })
+
       throw e
     }
   }
 
-  async render(now) {
+  async _renderRepo(now, repo) {
+    let { lastRender, logger, repoTemplate } = this
+    let {
+      config: { statusDirectory },
+      db
+    } = lookup()
+
+    let builds = await db.getBuilds(repo.id)
+
+    let updatedBuilds = builds.filter((b) => b.updated > lastRender)
+    if (updatedBuilds.length) {
+      logger.debug(`rendering repo page for ${repo.name}`, {
+        module: 'status/render'
+      })
+
+      let outputFile = resolve(statusDirectory, `${repo.name}.html`)
+
+      try {
+        await writeFile(
+          outputFile,
+          repoTemplate({
+            now,
+            repo_name: repo.name,
+            builds: builds.map((b) => augmentBuild(b))
+          })
+        )
+      } catch(e) {
+        logger.error(`error rendering ${repo.name}.html`, {
+          module: 'status/render'
+        })
+        logger.error(e.stack, { module: 'status/render' })
+
+        throw e
+      }
+
+      for (let build of updatedBuilds) {
+        await this._renderBuild(repo, build)
+      }
+    }
+  }
+
+  async _renderIndex(now) {
+    let { lastRender, logger, indexTemplate } = this
+
+    let {
+      config: { statusDirectory, indexBuildCount },
+      db
+    } = lookup()
+
+    let lastBuilds = await db.getLastUpdatedBuilds(indexBuildCount || 100)
+    if (!lastBuilds.length || lastBuilds.some((b) => b.updated > lastRender)) {
+      logger.debug('rendering index', { module: 'status/render' })
+      try {
+        await writeFile(
+          resolve(statusDirectory, 'index.html'),
+          indexTemplate({
+            now,
+            buildCount: indexBuildCount || '',
+            hasData: lastBuilds.length > 0,
+            builds: lastBuilds.map((b) => augmentBuild(b))
+          })
+        )
+      } catch(e) {
+        logger.error('error rendering index', { module: 'status/render' })
+        logger.error(e.stack, { module: 'status/render' })
+        throw e
+      }
+    }
+  }
+
+  async _render() {
     let { logger } = this
+    let { db } = lookup()
+    let now = Date.now()
 
-    await this.init()
-    let status = await this._readReposStatus()
+    await this._init()
 
-    for (let repoName in status) {
-      await this._renderRepo(now, repoName, status[repoName])
+    logger.debug('rendering status pages', {
+      module: 'status/render'
+    })
+
+    try {
+      for (let repo of await db.getRepos()) {
+        await this._renderRepo(now, repo)
+      }
+
+      await this._renderIndex(now)
+
+      this.lastRender = now
+
+      logger.debug('finished rendering status pages', {
+        module: 'status/render'
+      })
+    } catch(e) {
+      logger.error('error rendering status pages', {
+        module: 'status/render'
+      })
+      logger.error(e.stack, { module: 'status/render' })
     }
 
-    await this._renderIndex(now, status)
-    await this._setLastRender(now)
+    if (this.shouldRefresh) {
+      this.shouldRefresh = false
+      // Start a new async render
+      await this._render()
+    } else {
+      this.rendering = false
+    }
+  }
 
-    logger.debug('finished rendering status pages', { module: 'status/render' })
+  render() {
+    if (!this.rendering) {
+      // Start an async render
+      this.rendering = true
+      this._render()
+    } else {
+      // Already rendering, add refresh marker to render again after current
+      // render is finished
+      this.shouldRefresh = true
+    }
   }
 }
 
-register(Renderer)
+registerForTest(Renderer)
 registerLazy('renderer', () => new Renderer())

--- a/lib/status/status.js
+++ b/lib/status/status.js
@@ -1,17 +1,6 @@
-const { resolve } = require('path')
-const { mkdir, readdir, readFile, writeFile } = require('fs-extra')
-
-const { lookup, register, registerLazy } = require('../injections')
+const { lookup, registerForTest, registerLazy } = require('../injections')
 
 class Status {
-  get statusRoot() {
-    let {
-      config: { workingDirectory }
-    } = lookup()
-
-    return resolve(workingDirectory, 'status')
-  }
-
   get logger() {
     if (!this._logger) {
       let { getLogger } = lookup()
@@ -21,206 +10,75 @@ class Status {
   }
 
   async abortStaleBuilds() {
-    let { statusRoot } = this
-    let { githubStatus, renderer } = lookup()
-    let didSomething = false
-    let now = Date.now()
+    let { db, githubStatus } = lookup()
 
-    await this._ensureDirsExist()
+    let stepInfo = '(stale build was aborted)'
 
-    for (let file of await readdir(statusRoot)) {
-      if (file === 'peon-status.json') {
-        continue
-      }
-
-      let status = JSON.parse(await readFile(resolve(statusRoot, file)))
-      let changed = false
-
-      for (let buildId in status.builds) {
-        let build = status.builds[buildId]
-        if (build.status !== 'pending' && build.status !== 'running') {
-          continue
-        }
-
-        didSomething = changed = true
-        build.status = 'cancelled'
-        build.updated = now
-
-        let runningStep = build.steps.find((s) => s.status === 'running')
-        if (runningStep) {
-          runningStep.status = 'failed'
-          runningStep.output = 'stale build was aborted'
-        }
-
-        githubStatus.update(
-          build.url,
-          buildId,
-          build.sha,
-          'error',
-          'Peon stale build was aborted'
-        )
-      }
-
-      if (changed) {
-        await writeFile(resolve(statusRoot, file), JSON.stringify(status))
-      }
-    }
-
-    if (didSomething) {
-      await renderer.render(Date.now())
-    }
-  }
-
-  async _ensureDirsExist() {
-    let { statusRoot } = this
-
-    try {
-      await mkdir(statusRoot, { recursive: true })
-    } catch(e) {
-      if (e.code !== 'EEXIST') {
-        throw e
-      }
-    }
-  }
-
-  async _updateRepoStatus(repoName, updater) {
-    let { logger, statusRoot } = this
-    let ret, repoStatus
-    let now = Date.now()
-
-    try {
-      await this._ensureDirsExist()
-
-      let statusFile = resolve(statusRoot, `${repoName}.json`)
-
-      try {
-        repoStatus = JSON.parse(await readFile(statusFile))
-      } catch(e) {
-        repoStatus = {
-          nextBuildNum: 1,
-          builds: {}
+    for (let { id } of await db.getStaleBuilds()) {
+      for (let { description, status: stepStatus, output } of await db.getSteps(
+        id
+      )) {
+        if (stepStatus === 'running') {
+          await db.updateStep({
+            buildId: id,
+            description,
+            status: 'failed',
+            output: output ? `${output}\n${stepInfo}` : stepInfo
+          })
         }
       }
 
-      ret = updater(repoStatus, now)
-
-      await writeFile(statusFile, JSON.stringify(repoStatus))
-    } catch(e) {
-      logger.error(`could not update status for ${repoName}`, {
-        module: 'status'
-      })
-      logger.error(e.stack, { module: 'status' })
-      return
+      await db.updateBuild({ id, status: 'cancelled' })
+      githubStatus.update(id, 'error', 'Peon stale build was aborted')
     }
-
-    let { renderer } = lookup()
-
-    try {
-      await renderer.render(Date.now())
-    } catch(e) {
-      logger.error('could not render status pages', { module: 'status' })
-      logger.error(e.stack, { module: 'status' })
-      return
-    }
-
-    return ret
   }
 
   // Returns buildId
   async startBuild(repoUrl, repoName, refMode, ref, sha) {
-    return await this._updateRepoStatus(repoName, (repoStatus, now) => {
-      let buildNum = repoStatus.nextBuildNum
-      repoStatus.nextBuildNum++
-      let buildId = `${repoName}#${buildNum}`
+    let { db, githubStatus, renderer } = lookup()
 
-      let { githubStatus } = lookup()
-      githubStatus.update(
-        repoUrl,
-        buildId,
-        sha,
-        'pending',
-        'Peon build is queued'
-      )
+    let repo = await db.getOrCreateRepo({ name: repoName, url: repoUrl })
+    let buildId = await db.createBuild({ repoId: repo.id, refMode, ref, sha })
 
-      repoStatus.builds[buildId] = {
-        branch: refMode === 'branch' ? ref : null,
-        tag: refMode === 'tag' ? ref : null,
-        sha,
-        url: repoUrl,
-        enqueued: now,
-        updated: now,
-        status: 'pending',
-        steps: []
-      }
+    githubStatus.update(buildId, 'pending', 'Peon build is queued')
 
-      return buildId
-    })
+    renderer.render()
+
+    return buildId
   }
 
   async updateBuildStep(buildId, description, status, output) {
-    let [repoName] = buildId.split('#')
+    let { db, githubStatus, renderer } = lookup()
 
-    await this._updateRepoStatus(repoName, (repoStatus, now) => {
-      let build = repoStatus.builds[buildId]
+    await db.updateStep({ buildId, description, status, output })
 
-      let { githubStatus } = lookup()
-      githubStatus.update(
-        build.url,
-        buildId,
-        build.sha,
-        'pending',
-        `Peon build is running '${description}'`
-      )
+    githubStatus.update(
+      buildId,
+      'pending',
+      `Peon build is running '${description}'`
+    )
 
-      build.status = 'running'
-      build.updated = now
-      if (!('start' in build)) {
-        build.start = now
-      }
-
-      let { steps } = build
-      let step = steps.find((s) => s.description === description)
-      if (!step) {
-        step = { description, start: now }
-        steps.push(step)
-      }
-      step.status = status
-      step.output = output
-
-      if (status === 'success' || status === 'failed') {
-        step.end = now
-        step.duration = step.end - step.start
-      }
-    })
+    renderer.render()
   }
 
   async finishBuild(buildId, buildStatus, extra) {
-    let [repoName] = buildId.split('#')
+    let { db, githubStatus, renderer } = lookup()
 
-    await this._updateRepoStatus(repoName, (repoStatus, now) => {
-      let build = repoStatus.builds[buildId]
+    await db.updateBuild({ id: buildId, status: buildStatus, extra })
 
-      let { githubStatus } = lookup()
-      githubStatus.update(
-        build.url,
-        buildId,
-        build.sha,
-        buildStatus === 'success' ? 'success' : 'failure',
-        buildStatus === 'success'
-          ? 'Peon build is finished'
-          : buildStatus === 'cancelled'
-            ? 'Peon build was cancelled'
-            : 'Peon build has failed'
-      )
+    githubStatus.update(
+      buildId,
+      buildStatus === 'success' ? 'success' : 'failure',
+      buildStatus === 'success'
+        ? 'Peon build is finished'
+        : buildStatus === 'cancelled'
+          ? 'Peon build was cancelled'
+          : 'Peon build has failed'
+    )
 
-      build.status = buildStatus
-      build.end = now
-      build.updated = now
-      build.duration = build.end - build.start
-      build.extra = extra
-    })
+    renderer.render()
   }
 }
 
-register(Status)
+registerForTest(Status)
 registerLazy('status', () => new Status())

--- a/lib/watch/watcher.js
+++ b/lib/watch/watcher.js
@@ -115,9 +115,9 @@ class Watcher extends EventEmitter {
     let currentSHAs = {}
     if (!cloned) {
       for (let branch of branches) {
-        currentSHAs[branch] = (await repo.getBranchCommit(
-          `origin/${branch}`
-        )).sha()
+        currentSHAs[branch] = (
+          await repo.getBranchCommit(`origin/${branch}`)
+        ).sha()
         this.debug(`current SHA for branch ${branch} is ${currentSHAs[branch]}`)
       }
     }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "nodegit": "^0.24.0",
     "require-directory": "^2.1.1",
     "rsync": "^0.6.1",
+    "sql-template-strings": "^2.2.2",
+    "sqlite": "^3.0.3",
     "tar": "^4.4.8",
     "winston": "^3.1.0"
   },

--- a/templates/build.hbs
+++ b/templates/build.hbs
@@ -1,5 +1,5 @@
-<title>{{buildId}} - Peon</title>
-{{#if isRunning}}
+<title>Build #{{id}} on {{repo_name}} - Peon</title>
+{{#if is_running}}
   <meta http-equiv="refresh" content="5">
 {{/if}}
 <style>
@@ -22,11 +22,11 @@
   }
 </style>
 
-<h1 class="status-{{status}}">Build {{buildId}} <span class="duration">({{time duration}})</span></h1>
-<a href="../{{repoName}}.html">View all builds for {{repoName}}</a> &ndash;
-<a href="../index.html">Peon status page</a><br><br>
+<h1 class="status-{{status}}">Build #{{id}} on {{repo_name}} <span class="duration">({{time run_time}})</span></h1>
+<a href="{{repo_link}}">View all builds for {{repo_name}}</a> &ndash;
+<a href="index.html">Peon status page</a><br><br>
 
-Building SHA {{sha}} on {{branch}}{{tag}}<br>
+Building SHA {{sha}} on {{ref_type}} {{ref}}<br>
 Enqueued at {{date enqueued}}<br>
 {{#if start}}Started at {{date start}}<br>{{/if}}
 {{#if end}}Finished at {{date end}}<br>{{/if}}

--- a/templates/buildredir.hbs
+++ b/templates/buildredir.hbs
@@ -1,0 +1,2 @@
+<meta http-equiv="refresh" content="0;URL=../{{id}}.html" >
+<a href="../{{id}}.html">This page has moved.</a>

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -18,7 +18,7 @@
 <h1>Peon status page</h1>
 
 {{#if hasData}}
-  <h2>Last 100 builds</h2>
+  <h2>Last {{buildCount}} builds</h2>
 
   <table width="100%">
     <tr>
@@ -50,13 +50,13 @@
     {{#each builds}}
       <tr class="status-{{status}}">
         <td>
-          <a href="{{repoLink}}">{{repoName}}</a>
+          <a href="{{repo_link}}">{{repo_name}}</a>
         </td>
         <td>
-          <a href="{{link}}">{{buildNum}}</a>
+          <a href="{{build_link}}">{{id}}</a>
         </td>
         <td>
-          {{refMode}}
+          {{ref_type}}
         </td>
         <td>
           {{ref}}
@@ -66,14 +66,14 @@
         </td>
         <td>
           {{#if start}}
-            {{time queueTime}}
+            {{time queue_time}}
           {{else}}
             &ndash;
           {{/if}}
         </td>
         <td>
           {{#if end}}
-            {{time runTime}}
+            {{time run_time}}
           {{else}}
             &ndash;
           {{/if}}

--- a/templates/repo.hbs
+++ b/templates/repo.hbs
@@ -1,4 +1,4 @@
-<title>{{repoName}} - Peon</title>
+<title>{{repo_name}} - Peon</title>
 <meta http-equiv="refresh" content="5">
 <style>
   .status-pending,
@@ -19,7 +19,7 @@
 <h1>Peon status</h1>
 <a href="index.html">Peon status page</a>
 
-<h2>Builds for {{repoName}}</h2>
+<h2>Builds for {{repo_name}}</h2>
 
 <table width="100%">
   <tr>
@@ -48,10 +48,10 @@
   {{#each builds}}
     <tr class="status-{{status}}">
       <td>
-        <a href="{{link}}">{{buildNum}}</a>
+        <a href="{{build_link}}">{{id}}</a>
       </td>
       <td>
-        {{refMode}}
+        {{ref_type}}
       </td>
       <td>
         {{ref}}
@@ -64,14 +64,14 @@
       </td>
       <td>
         {{#if start}}
-          {{time queueTime}}
+          {{time queue_time}}
         {{else}}
           &ndash;
         {{/if}}
       </td>
       <td>
         {{#if end}}
-          {{time runTime}}
+          {{time run_time}}
         {{else}}
           &ndash;
         {{/if}}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,6 +8,10 @@ const { lookup, register } = require(`${src}/injections`)
 
 const pendingCleanup = []
 
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 module.exports = {
   // Paths to peon sources
   root,
@@ -58,10 +62,22 @@ module.exports = {
     while (pendingCleanup.length) {
       await pendingCleanup.pop()()
     }
+
+    let { db } = lookup()
+    db.close()
   },
 
   // Return a promise that resolves in ms milliseconds
-  wait(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms))
+  wait,
+
+  async waitUntil(predicate, timeout = 1000)  {
+    let start = Date.now()
+    while (!predicate()) {
+      if (Date.now() > start + timeout) {
+        throw new Error('waitUntil timed out')
+      }
+
+      await wait(10)
+    }
   }
 }

--- a/test/init.js
+++ b/test/init.js
@@ -1,6 +1,6 @@
 const { src, cleanup } = require('./helpers')
 const Peon = require(`${src}/peon`)
 
-Peon.loadModules()
+Peon.loadModules(true /* test mode */)
 
 afterEach(cleanup)

--- a/test/unit/status/db.test.js
+++ b/test/unit/status/db.test.js
@@ -1,0 +1,389 @@
+/* eslint-disable camelcase */
+
+const { assert } = require('chai')
+const SQL = require('sql-template-strings')
+
+const { lookup, tempDir, mockConfig } = require('../../helpers')
+
+const { Database } = lookup()
+
+const fixtures = {
+  repos: SQL`
+INSERT INTO Repo(id, name, url)
+VALUES (1, 'myrepo1', 'myurl1'), (2, 'myrepo2', 'myurl2')`,
+
+  builds: SQL`
+INSERT INTO Build(id, repo_id, ref_type, ref, sha, enqueued, updated, start,
+                  end, status, extra)
+VALUES (1, 1, 'branch', 'mybranch', 'sha1', 0, 1, 2, 3, 'status', null),
+       (2, 1, 'tag', 'mytag', 'sha2', 4, 5, 6, 7, 'status', '{"json":"value"}'),
+       (3, 2, 'branch', 'mybranch', 'sha3', 8, 9, 10, 11, 'status', null),
+       (4, 2, 'tag', 'mytag', 'sha4', 12, 13, 14, 15, 'status', null),
+       (5, 2, 'tag', 'mytag', 'sha4', 12, 14, 14, 15, 'pending', null),
+       (6, 2, 'tag', 'mytag', 'sha4', 12, 15, 14, 15, 'running', null)`,
+
+  steps: SQL`
+INSERT INTO Step(id, build_id, description, start, end, status, output)
+VALUES (1, 1, 'build 1 step 1', 0, 1, 'success', '1.1 output'),
+       (2, 1, 'build 1 step 2', 2, 3, 'success', '1.2 output'),
+       (3, 1, 'build 1 step 3', 4, null, 'running', '1.3 output'),
+       (4, 2, 'build 2 step 1', 6, 7, 'success', '2.1 output'),
+       (5, 2, 'build 2 step 2', 8, 9, 'failed', '2.2 output')`
+}
+
+describe('Unit | status/db', function() {
+  let _dbs = []
+
+  async function getDatabase(queries = [], config = {}) {
+    mockConfig('workingDirectory', await tempDir())
+
+    for (let key in config) {
+      mockConfig(key, config[key])
+    }
+
+    let db = new Database()
+
+    await db.db
+    for (let query of queries) {
+      await db._run(query)
+    }
+
+    _dbs.push(db)
+    return db
+  }
+
+  afterEach(async function() {
+    for (let db of _dbs) {
+      await db.close()
+    }
+
+    _dbs.splice(0, _dbs.length)
+  })
+
+  describe('db.getRepos', function() {
+    it('returns repositories', async function() {
+      let db = await getDatabase([fixtures.repos])
+
+      let repos = await db.getRepos()
+
+      assert.deepEqual(repos, [
+        { id: 1, name: 'myrepo1', url: 'myurl1' },
+        { id: 2, name: 'myrepo2', url: 'myurl2' }
+      ])
+    })
+  })
+
+  describe('db.getOrCreateRepo', function() {
+    it('returns existing repo', async function() {
+      let db = await getDatabase([fixtures.repos])
+
+      let repo = await db.getOrCreateRepo({
+        name: 'myrepo1',
+        url: 'myurl1'
+      })
+
+      assert.deepEqual(repo, { id: 1, name: 'myrepo1', url: 'myurl1' })
+    })
+
+    it('returns existing repo without changing url', async function() {
+      let db = await getDatabase([fixtures.repos])
+
+      let repo = await db.getOrCreateRepo({
+        name: 'myrepo1',
+        url: 'myotherurl1'
+      })
+
+      assert.deepEqual(repo, { id: 1, name: 'myrepo1', url: 'myurl1' })
+    })
+
+    it('creates missing repo', async function() {
+      let db = await getDatabase([fixtures.repos])
+
+      let repo = await db.getOrCreateRepo({
+        name: 'myrepo3',
+        url: 'myurl3'
+      })
+
+      assert.deepEqual(repo, { id: 3, name: 'myrepo3', url: 'myurl3' })
+    })
+  })
+
+  describe('db.getBuilds', function() {
+    it('returns builds last updated first', async function() {
+      let db = await getDatabase([fixtures.repos, fixtures.builds])
+
+      let builds = await db.getBuilds(1)
+
+      assert.deepEqual(builds, [
+        {
+          id: 2, ref_type: 'tag', ref: 'mytag', sha: 'sha2', enqueued: 4,
+          updated: 5, start: 6, end: 7, status: 'status',
+          extra: { json: 'value' }
+        },
+        {
+          id: 1, ref_type: 'branch', ref: 'mybranch', sha: 'sha1', enqueued: 0,
+          updated: 1, start: 2, end: 3, status: 'status', extra: null
+        }
+      ])
+    })
+  })
+
+  describe('db.getStaleBuilds', function() {
+    it('returns running or pending build IDs', async function() {
+      let db = await getDatabase([fixtures.repos, fixtures.builds])
+
+      let ids = await db.getStaleBuilds()
+
+      assert.deepEqual(ids, [{ id: 5 }, { id: 6 }])
+    })
+  })
+
+  describe('db.getLastUpdatedBuilds', function() {
+    it('returns all builds last updated first', async function() {
+      let db = await getDatabase([fixtures.repos, fixtures.builds])
+
+      let builds = await db.getLastUpdatedBuilds()
+
+      assert.deepEqual(
+        builds.map((b) => b.id),
+        [6, 5, 4, 3, 2, 1]
+      )
+    })
+
+    it('limits output count', async function() {
+      let db = await getDatabase([fixtures.repos, fixtures.builds])
+
+      let builds = await db.getLastUpdatedBuilds(2)
+
+      assert.deepEqual(
+        builds.map((b) => b.id),
+        [6, 5]
+      )
+    })
+  })
+
+  describe('db.createBuild', function() {
+    it('creates a new build', async function() {
+      let db = await getDatabase([fixtures.repos])
+
+      let id = await db.createBuild({
+        repoId: 1,
+        refMode: 'branch',
+        ref: 'mybranch',
+        sha: 'mysha'
+      })
+      let [build] = await db.getBuilds(1)
+
+      assert.ok(build)
+      assert.closeTo(build.enqueued, Date.now(), 500)
+      assert.equal(build.enqueued, build.updated)
+      assert.include(build, {
+        id, ref_type: 'branch', ref: 'mybranch', sha: 'mysha', start: null,
+        end: null, status: 'pending', extra: null
+      })
+    })
+  })
+
+  describe('db.updateBuild', function() {
+    it('sets status and updated fields', async function() {
+      let db = await getDatabase([
+        fixtures.repos,
+        fixtures.builds
+      ])
+
+      await db.updateBuild({ id: 1, status: 'newstatus' })
+      let [build] = await db.getBuilds(1)
+
+      assert.include(build, { status: 'newstatus', start: 2, end: 3, extra: null })
+      assert.closeTo(build.updated, Date.now(), 500)
+    })
+
+    it('sets start time when start is not set and status is not cancelled or failed', async function() {
+      let db = await getDatabase([
+        fixtures.repos,
+        fixtures.builds,
+        SQL`UPDATE Build SET start = null`
+      ])
+
+      await db.updateBuild({ id: 1, status: 'cancelled' })
+      await db.updateBuild({ id: 2, status: 'failed' })
+      let [build1, build2] = await db.getBuilds(1)
+
+      assert.equal(build1.start, null)
+      assert.equal(build2.start, null)
+
+      await db.updateBuild({ id: 1, status: 'running' })
+      let [build] = await db.getBuilds(1)
+
+      assert.closeTo(build.start, Date.now(), 500)
+    })
+
+    it('sets end time when status is failed or success', async function() {
+      let db = await getDatabase([
+        fixtures.repos,
+        fixtures.builds,
+        SQL`UPDATE Build SET end = null`
+      ])
+
+      await db.updateBuild({ id: 1, status: 'notfailed' })
+      await db.updateBuild({ id: 2, status: 'notsuccess' })
+      let [build1, build2] = await db.getBuilds(1)
+
+      assert.equal(build1.end, null)
+      assert.equal(build2.end, null)
+
+      await db.updateBuild({ id: 1, status: 'failed' })
+      await db.updateBuild({ id: 2, status: 'success' })
+      ;([build1, build2] = await db.getBuilds(1))
+
+      assert.closeTo(build1.end, Date.now(), 500)
+      assert.closeTo(build2.end, Date.now(), 500)
+    })
+
+    it('sets extra as JSON when specified', async function() {
+      let db = await getDatabase([
+        fixtures.repos,
+        fixtures.builds
+      ])
+
+      await db.updateBuild({ id: 1, status: 'newstatus', extra: { json: 'value' } })
+      let [build] = await db.getBuilds(1)
+
+      assert.deepEqual(build.extra, { json: 'value' })
+    })
+  })
+
+  describe('db.getSteps', function() {
+    it('returns steps in starting order', async function() {
+      let db = await getDatabase([fixtures.repos, fixtures.builds, fixtures.steps])
+
+      let steps = await db.getSteps(1)
+
+      assert.deepEqual(steps, [
+        { id: 1, description: 'build 1 step 1', start: 0, end: 1,
+          status: 'success', output: '1.1 output' },
+        { id: 2, description: 'build 1 step 2', start: 2, end: 3,
+          status: 'success', output: '1.2 output' },
+        { id: 3, description: 'build 1 step 3', start: 4, end: null,
+          status: 'running', output: '1.3 output' }
+      ])
+    })
+  })
+
+  describe('db.updateStep', function() {
+    it('sets build status to running', async function() {
+      let db = await getDatabase([
+        fixtures.repos,
+        fixtures.builds,
+        fixtures.steps
+      ])
+
+      await db.updateStep({
+        buildId: 1, description: 'build 1 step 3', status: 'running'
+      })
+      let [build] = await db.getBuilds(1)
+
+      assert.equal(build.status, 'running')
+    })
+
+    it('creates step if missing', async function() {
+      let db = await getDatabase([
+        fixtures.repos,
+        fixtures.builds,
+        fixtures.steps
+      ])
+
+      await db.updateStep({
+        buildId: 1,
+        description: 'build 1 step 4',
+        status: 'running'
+      })
+
+      let [,,, step] = await db.getSteps(1)
+
+      assert.include(step, {
+        id: 6,
+        description: 'build 1 step 4',
+        status: 'running'
+      })
+    })
+
+    it('updates step status', async function() {
+      let db = await getDatabase([
+        fixtures.repos,
+        fixtures.builds,
+        fixtures.steps
+      ])
+
+      await db.updateStep({
+        buildId: 1,
+        description: 'build 1 step 1',
+        status: 'moo'
+      })
+
+      let [step] = await db.getSteps(1)
+
+      assert.equal(step.status, 'moo')
+    })
+
+    it('sets step end when status is success or failed', async function() {
+      let db = await getDatabase([
+        fixtures.repos,
+        fixtures.builds,
+        fixtures.steps
+      ])
+
+      await db.updateStep({
+        buildId: 1,
+        description: 'build 1 step 1',
+        status: 'success'
+      })
+      await db.updateStep({
+        buildId: 1,
+        description: 'build 1 step 2',
+        status: 'failed'
+      })
+
+      let [step1, step2] = await db.getSteps(1)
+
+      assert.closeTo(step1.end, Date.now(), 500)
+      assert.closeTo(step2.end, Date.now(), 500)
+    })
+
+    it('sets step output if specified', async function() {
+      let db = await getDatabase([
+        fixtures.repos,
+        fixtures.builds,
+        fixtures.steps
+      ])
+
+      await db.updateStep({
+        buildId: 1,
+        description: 'build 1 step 1',
+        status: 'success'
+      })
+      let [step] = await db.getSteps(1)
+
+      assert.equal(step.output, '1.1 output')
+
+      await db.updateStep({
+        buildId: 1,
+        description: 'build 1 step 1',
+        status: 'success',
+        output: 'moo'
+      })
+      ;([step] = await db.getSteps(1))
+
+      assert.equal(step.output, 'moo')
+    })
+  })
+
+  describe('db.getGitBuildInfo', function() {
+    it('retrieves build SHA and repository URL', async function() {
+      let db = await getDatabase([fixtures.repos, fixtures.builds])
+
+      let info = await db.getGitBuildInfo(1)
+      assert.deepEqual(info, { sha: 'sha1', url: 'myurl1' })
+    })
+  })
+})

--- a/test/unit/status/render.test.js
+++ b/test/unit/status/render.test.js
@@ -1,19 +1,21 @@
+/* eslint-disable camelcase */
+
 const { assert } = require('chai')
-const { mkdir, readFile, writeFile } = require('fs-extra')
+const { readFile } = require('fs-extra')
 const { resolve } = require('path')
-const { lookup, mock, mockConfig, tempDir } = require('../../helpers')
+const { lookup, mock, mockConfig, tempDir, wait, waitUntil } = require('../../helpers')
 const { Renderer } = lookup()
 
 describe('unit | status/render', function() {
-  let workingDirectory
+  let statusDirectory
 
   beforeEach(async function() {
-    workingDirectory = await tempDir()
-    mockConfig('workingDirectory', workingDirectory)
+    statusDirectory = await tempDir()
+    mockConfig('statusDirectory', statusDirectory)
   })
 
-  describe('Renderer.init', function() {
-    it('registers a date helper', async function() {
+  describe('Renderer._init', function() {
+    it('registers handlebars helpers', async function() {
       let helpers = {}
       mock('Handlebars', {
         compile() {},
@@ -23,260 +25,201 @@ describe('unit | status/render', function() {
       })
 
       let renderer = new Renderer()
-      await renderer.init()
+      await renderer._init()
 
       assert.isFunction(helpers.date)
+      assert.equal(
+        helpers.date(Number(new Date('2001-02-03T04:05:06Z'))),
+        '2001-02-03T04:05:06.000Z'
+      )
 
-      let date = new Date('2001-02-03T04:05:06Z')
-      assert.equal(helpers.date(Number(date)), '2001-02-03T04:05:06.000Z')
+      assert.isFunction(helpers.shortsha)
+      assert.equal(helpers.shortsha('abcdefghijkl'), 'abcdefgh')
+
+      assert.isFunction(helpers.time)
+      assert.equal(helpers.time(null), '')
+      assert.equal(helpers.time(50), '50ms')
+      assert.equal(helpers.time(5678), '5.7s')
+      assert.equal(helpers.time(67890), '1m07s')
     })
 
     it('compiles templates', async function() {
       let renderer = new Renderer()
-      await renderer.init()
+      await renderer._init()
 
       assert.isFunction(renderer.indexTemplate)
       assert.isFunction(renderer.buildTemplate)
-    })
-  })
-
-  describe('Renderer._getLastRender', function() {
-    it('returns 0 when no previous render was done', async function() {
-      let renderer = new Renderer()
-      assert.equal(await renderer._getLastRender(), 0)
-      assert.equal(renderer.lastRender, 0)
-    })
-
-    it('returns last render date from saved JSON file', async function() {
-      let renderer = new Renderer()
-
-      await mkdir(resolve(workingDirectory, 'status'))
-      await writeFile(
-        resolve(workingDirectory, 'status', 'peon-status.json'),
-        JSON.stringify({ lastRender: 1234 })
-      )
-
-      assert.equal(await renderer._getLastRender(), 1234)
-      assert.equal(renderer.lastRender, 1234)
-    })
-
-    it('does not read JSON file again when last render is already known', async function() {
-      let renderer = new Renderer()
-
-      await mkdir(resolve(workingDirectory, 'status'))
-      await writeFile(
-        resolve(workingDirectory, 'status', 'peon-status.json'),
-        'invalid json'
-      )
-
-      renderer.lastRender = 1234
-      assert.equal(await renderer._getLastRender(), 1234)
-      assert.equal(renderer.lastRender, 1234)
-    })
-  })
-
-  describe('Renderer._setLastRender', function() {
-    it('sets last render property and saves to JSON file', async function() {
-      let renderer = new Renderer()
-      await renderer._setLastRender(1234)
-      assert.equal(renderer.lastRender, 1234)
-      assert.deepEqual(
-        JSON.parse(
-          await readFile(
-            resolve(workingDirectory, 'status', 'peon-status.json')
-          )
-        ),
-        { lastRender: 1234 }
-      )
-    })
-  })
-
-  describe('Renderer._readReposStatus', function() {
-    it('reads nothing when no status files are present', async function() {
-      assert.deepEqual(await new Renderer()._readReposStatus(), {})
-    })
-
-    it('ignores peon-status.json', async function() {
-      await mkdir(resolve(workingDirectory, 'status'))
-      await writeFile(
-        resolve(workingDirectory, 'status', 'peon-status.json'),
-        'invalid json'
-      )
-
-      assert.deepEqual(await new Renderer()._readReposStatus(), {})
-    })
-
-    it('reads data from repo status files', async function() {
-      await mkdir(resolve(workingDirectory, 'status'))
-      await writeFile(
-        resolve(workingDirectory, 'status', 'repo1.json'),
-        JSON.stringify({
-          data: { from: 'repo1' }
-        })
-      )
-      await writeFile(
-        resolve(workingDirectory, 'status', 'repo2.json'),
-        JSON.stringify({
-          data: { from: 'repo2' }
-        })
-      )
-
-      assert.deepEqual(await new Renderer()._readReposStatus(), {
-        repo1: { data: { from: 'repo1' } },
-        repo2: { data: { from: 'repo2' } }
-      })
+      assert.isFunction(renderer.repoTemplate)
     })
   })
 
   describe('Renderer._renderBuild', function() {
-    let statusDirectory
 
-    beforeEach(async function() {
-      statusDirectory = await tempDir()
-      mockConfig('statusDirectory', statusDirectory)
-    })
-
-    it('does not render a build when not updated since last render', async function() {
-      let renderer = new Renderer()
-      renderer.lastRender = 1234
-      renderer.buildTemplate = function() {
-        throw new Error('should not be called')
-      }
-
-      await renderer._renderBuild('repo#100', { updated: 1000 })
-      assert.ok(true)
-    })
-
-    it('renders build when updated since last render', async function() {
+    it('renders build', async function() {
       let renderer = new Renderer()
       let templateData
-      renderer.lastRender = 1234
+
+      mock('db', {
+        async getSteps(id) {
+          assert.equal(id, 100)
+          return [
+            { step: 'step1', start: 100, end: 200 },
+            { step: 'step2', start: 100 }
+          ]
+        }
+      })
+
       renderer.buildTemplate = function(data) {
         templateData = data
         return 'template render output'
       }
 
-      await renderer._renderBuild('repo#100', {
-        updated: 2000,
+      await renderer._renderBuild({ name: 'repo' }, {
+        id: 100,
         data: 'some build data',
-        tag: 'mytag'
+        enqueued: 500,
+        start: 1000,
+        end: 2000
       })
 
       assert.deepEqual(templateData, {
-        buildId: 'repo#100',
-        buildNum: '100',
-        link: 'repo/100.html',
-        ref: 'mytag',
-        tag: 'mytag',
-        refMode: 'tag',
-        repoName: 'repo',
-        queueTime: null,
-        runTime: null,
-        updated: 2000,
+        id: 100,
         data: 'some build data',
-        isRunning: false
+        enqueued: 500,
+        start: 1000,
+        end: 2000,
+
+        is_running: false,
+        queue_time: 500,
+        run_time: 1000,
+        repo_link: 'repo.html',
+        repo_name: 'repo',
+        build_link: '100.html',
+
+        steps: [
+          { step: 'step1', start: 100, end: 200, duration: 100 },
+          { step: 'step2', start: 100, duration: null }
+        ]
       })
 
       assert.equal(
-        await readFile(resolve(statusDirectory, 'repo', '100.html')),
+        await readFile(resolve(statusDirectory, '100.html')),
         'template render output'
       )
     })
 
-    it('passes isRunning=true when build is pending', async function() {
+    it('passes is_running=true when build is pending', async function() {
       let renderer = new Renderer()
       let templateData
-      renderer.lastRender = 1234
       renderer.buildTemplate = function(data) {
         templateData = data
       }
 
-      await renderer._renderBuild('repo#100', {
-        updated: 2000,
+      mock('db', {
+        async getSteps() {
+          return []
+        }
+      })
+
+      await renderer._renderBuild({ name: 'repo' }, {
+        id: 100,
         data: 'some build data',
         status: 'pending'
       })
 
-      assert.ok(templateData.isRunning)
+      assert.ok(templateData.is_running)
     })
 
-    it('passes isRunning=true when build is running', async function() {
+    it('passes is_running=true when build is running', async function() {
       let renderer = new Renderer()
       let templateData
-      renderer.lastRender = 1234
       renderer.buildTemplate = function(data) {
         templateData = data
       }
 
-      await renderer._renderBuild('repo#100', {
-        updated: 2000,
+      mock('db', {
+        async getSteps() {
+          return []
+        }
+      })
+
+      await renderer._renderBuild({ name: 'repo' }, {
+        id: 100,
         data: 'some build data',
         status: 'running'
       })
 
-      assert.ok(templateData.isRunning)
+      assert.ok(templateData.is_running)
     })
 
-    it('passes isRunning=false when build is successful', async function() {
+    it('passes is_running=false when build is successful', async function() {
       let renderer = new Renderer()
       let templateData
-      renderer.lastRender = 1234
       renderer.buildTemplate = function(data) {
         templateData = data
       }
 
-      await renderer._renderBuild('repo#100', {
-        updated: 2000,
+      mock('db', {
+        async getSteps() {
+          return []
+        }
+      })
+
+      await renderer._renderBuild({ name: 'repo' }, {
+        id: 100,
         data: 'some build data',
         status: 'success'
       })
 
-      assert.notOk(templateData.isRunning)
+      assert.notOk(templateData.is_running)
     })
 
-    it('passes isRunning=false when build is failed', async function() {
+    it('passes is_running=false when build is failed', async function() {
       let renderer = new Renderer()
       let templateData
-      renderer.lastRender = 1234
       renderer.buildTemplate = function(data) {
         templateData = data
       }
 
-      await renderer._renderBuild('repo#100', {
-        updated: 2000,
+      mock('db', {
+        async getSteps() {
+          return []
+        }
+      })
+
+      await renderer._renderBuild({ name: 'repo' }, {
+        id: 100,
         data: 'some build data',
         status: 'failed'
       })
 
-      assert.notOk(templateData.isRunning)
+      assert.notOk(templateData.is_running)
     })
 
-    it('passes isRunning=false when build is cancelled', async function() {
+    it('passes is_running=false when build is cancelled', async function() {
       let renderer = new Renderer()
       let templateData
-      renderer.lastRender = 1234
       renderer.buildTemplate = function(data) {
         templateData = data
       }
 
-      await renderer._renderBuild('repo#100', {
-        updated: 2000,
+      mock('db', {
+        async getSteps() {
+          return []
+        }
+      })
+
+      await renderer._renderBuild({ name: 'repo' }, {
+        id: 100,
         data: 'some build data',
         status: 'cancelled'
       })
 
-      assert.notOk(templateData.isRunning)
+      assert.notOk(templateData.is_running)
     })
   })
 
   describe('Renderer._renderRepo', function() {
-    let statusDirectory
-
-    beforeEach(async function() {
-      statusDirectory = await tempDir()
-      mockConfig('statusDirectory', statusDirectory)
-    })
-
     it('calls _renderBuild for each build and renders repo page', async function() {
       let log = []
       let renderer = new Renderer()
@@ -292,54 +235,56 @@ describe('unit | status/render', function() {
       }
 
       let now = Date.now()
-      let earlier = now - 1000
+      renderer.lastRender = now - 1000
 
-      await renderer._renderRepo(now, 'repo', {
-        builds: {
-          'repo#1': {
-            data: 'build 1 data',
-            branch: 'mybranch',
-            updated: earlier
-          },
-          'repo#2': {
-            data: 'build 2 data',
-            tag: 'mytag',
-            updated: earlier
-          }
+      mock('db', {
+        async getBuilds() {
+          return  [
+            {
+              id: 2,
+              data: 'build 2 data',
+              ref_type: 'tag',
+              ref: 'mytag',
+              updated: now + 1
+            },
+            {
+              id: 1,
+              data: 'build 1 data',
+              ref_type: 'branch',
+              ref: 'mybranch',
+              updated: now
+            }
+          ]
         }
       })
+
+      await renderer._renderRepo(now, { id: 1, name: 'repo' })
 
       assert.deepEqual(templateData, {
         builds: [
           {
-            buildId: 'repo#2',
-            buildNum: '2',
+            id: 2,
             data: 'build 2 data',
-            link: 'repo/2.html',
-            queueTime: null,
             ref: 'mytag',
-            refMode: 'tag',
-            tag: 'mytag',
-            repoName: 'repo',
-            runTime: null,
-            updated: earlier
+            ref_type: 'tag',
+            updated: now + 1,
+            run_time: null,
+            build_link: '2.html',
+            queue_time: null
           },
           {
-            buildId: 'repo#1',
-            buildNum: '1',
+            id: 1,
             data: 'build 1 data',
-            link: 'repo/1.html',
-            queueTime: null,
             ref: 'mybranch',
-            refMode: 'branch',
-            branch: 'mybranch',
-            repoName: 'repo',
-            runTime: null,
-            updated: earlier
+            ref_type: 'branch',
+            updated: now,
+            run_time: null,
+            build_link: '1.html',
+            queue_time: null
           }
         ],
         now,
-        repoName: 'repo'
+        repo_name: 'repo'
       })
 
       assert.equal(
@@ -349,29 +294,32 @@ describe('unit | status/render', function() {
 
       assert.deepEqual(log, [
         [
-          'repo#1',
-          { data: 'build 1 data', branch: 'mybranch', updated: earlier }
+          { id: 1, name: 'repo' },
+          { id: 2, data: 'build 2 data', ref: 'mytag', ref_type: 'tag', updated: now + 1 }
         ],
-        ['repo#2', { data: 'build 2 data', tag: 'mytag', updated: earlier }]
+        [
+          { id: 1, name: 'repo' },
+          { id: 1, data: 'build 1 data', ref: 'mybranch', ref_type: 'branch', updated: now }
+        ]
       ])
     })
   })
 
   describe('Renderer._renderIndex', function() {
-    let statusDirectory
-
-    beforeEach(async function() {
-      statusDirectory = await tempDir()
-      mockConfig('statusDirectory', statusDirectory)
-    })
-
     it('renders index', async function() {
       let renderer = new Renderer()
+
       renderer.indexTemplate = function() {
         return 'rendered template data'
       }
 
-      await renderer._renderIndex(1, {})
+      mock('db', {
+        async getLastUpdatedBuilds() {
+          return []
+        }
+      })
+
+      await renderer._renderIndex(1)
 
       assert.equal(
         await readFile(resolve(statusDirectory, 'index.html')),
@@ -386,7 +334,13 @@ describe('unit | status/render', function() {
         templateData = data
       }
 
-      await renderer._renderIndex(1, { repo: { builds: {} } })
+      mock('db', {
+        async getLastUpdatedBuilds() {
+          return []
+        }
+      })
+
+      await renderer._renderIndex(1)
 
       assert.notOk(templateData.hasData)
     })
@@ -398,7 +352,13 @@ describe('unit | status/render', function() {
         templateData = data
       }
 
-      await renderer._renderIndex(1, { repo: { builds: { 'repo#1': {} } } })
+      mock('db', {
+        async getLastUpdatedBuilds() {
+          return [{ repo_name: 'repo', updated: 100 }]
+        }
+      })
+
+      await renderer._renderIndex(1)
 
       assert.ok(templateData.hasData)
     })
@@ -410,7 +370,13 @@ describe('unit | status/render', function() {
         templateData = data
       }
 
-      await renderer._renderIndex(1234, { repo: { builds: {} } })
+      mock('db', {
+        async getLastUpdatedBuilds() {
+          return []
+        }
+      })
+
+      await renderer._renderIndex(1234)
 
       assert.equal(templateData.now, 1234)
     })
@@ -423,70 +389,170 @@ describe('unit | status/render', function() {
       }
       renderer.indexBuildCount = 5
 
-      await renderer._renderIndex(1, {
-        repoA: {
-          builds: {
-            'repoA#1': { status: 'success', updated: 1 },
-            'repoA#2': { status: 'success', updated: 2 },
-            'repoA#3': { status: 'success', updated: 3 },
-            'repoA#4': { status: 'failed', updated: 4 },
-            'repoA#5': { status: 'success', updated: 5 },
-            'repoA#6': { status: 'cancelled', updated: 6 },
-            'repoA#7': { status: 'success', updated: 7 },
-            'repoA#8': { status: 'failed', updated: 8 },
-            'repoA#9': { status: 'success', updated: 9 },
-            'repoA#10': { status: 'success', updated: 11 },
-            'repoA#11': { status: 'success', updated: 12 }
-          }
-        },
-        repoB: {
-          builds: {
-            'repoB#1': { status: 'failed', updated: 10 }
-          }
+      mock('db', {
+        async getLastUpdatedBuilds() {
+          return [
+            { id: 1, updated: 100 },
+            { id: 2, updated: 99 },
+            { id: 3, updated: 98 },
+            { id: 4, updated: 97 },
+            { id: 5, updated: 96 }
+          ]
         }
       })
 
-      assert.deepEqual(templateData.builds.map((b) => b.buildId), [
-        'repoA#11',
-        'repoA#10',
-        'repoB#1',
-        'repoA#9',
-        'repoA#8'
+      await renderer._renderIndex(1)
+
+      assert.deepEqual(templateData.builds.map((b) => b.id), [1, 2, 3, 4, 5])
+    })
+
+    it('does not render when no build was updated', async function() {
+      let renderer = new Renderer()
+      let rendered = false
+
+      renderer.lastRender = 200
+      renderer.indexTemplate = function() {
+        rendered = true
+      }
+
+      mock('db', {
+        async getLastUpdatedBuilds() {
+          return [
+            { id: 1, updated: 100 },
+            { id: 2, updated: 99 },
+            { id: 3, updated: 98 },
+            { id: 4, updated: 97 },
+            { id: 5, updated: 96 }
+          ]
+        }
+      })
+
+      await renderer._renderIndex(1)
+
+      assert.notOk(rendered)
+    })
+  })
+
+  describe('Renderer._render', function() {
+    it('loads repos, renders each repo, renders index, sets rendering to false', async function() {
+      let log = []
+      let renderer = new Renderer()
+
+      mock('db', {
+        async getRepos() {
+          log.push('fetch repos')
+
+          return [
+            { id: 1, name: 'repo 1' },
+            { id: 2, name: 'repo 2' }
+          ]
+        }
+      })
+
+      renderer._renderRepo = async function(now, repo) {
+        assert.closeTo(now, Date.now(), 500)
+        log.push(`render with ${repo.name}`)
+      }
+
+      renderer._renderIndex = async function(now) {
+        assert.closeTo(now, Date.now(), 500)
+        log.push('render index')
+      }
+
+      renderer.rendering = true
+      await renderer._render()
+
+      assert.notOk(renderer.rendering)
+
+      assert.deepEqual(log, [
+        'fetch repos',
+        'render with repo 1',
+        'render with repo 2',
+        'render index'
       ])
+    })
+
+    it('renders again when shouldRefresh is marked', async function() {
+      let log = []
+      let renderer = new Renderer()
+
+      mock('db', {
+        async getRepos() {
+          log.push('fetch repos')
+
+          return [
+            { id: 1, name: 'repo 1' },
+            { id: 2, name: 'repo 2' }
+          ]
+        }
+      })
+
+      renderer._renderRepo = async function(now, repo) {
+        assert.closeTo(now, Date.now(), 500)
+        log.push(`render with ${repo.name}`)
+      }
+
+      renderer._renderIndex = async function(now) {
+        assert.closeTo(now, Date.now(), 500)
+        log.push('render index')
+      }
+
+      renderer.shouldRefresh = true
+      await renderer._render()
+
+      assert.deepEqual(log, [
+        'fetch repos',
+        'render with repo 1',
+        'render with repo 2',
+        'render index',
+        'fetch repos',
+        'render with repo 1',
+        'render with repo 2',
+        'render index'
+      ])
+
+      assert.notOk(renderer.shouldRefresh)
     })
   })
 
   describe('Renderer.render', function() {
-    it('loads repo status, renders builds, renders index and updates last render', async function() {
-      let log = []
+    it('queues an additional render when rendering is already in progress', async function() {
       let renderer = new Renderer()
 
-      renderer._readReposStatus = async function() {
-        log.push('read status')
-        return { repo1: 'repo 1 data', repo2: 'repo 2 data' }
-      }
-      renderer._renderRepo = async function(now, repo, status) {
-        log.push(`render with ${repo} ${status}`)
-      }
-      renderer._renderIndex = async function(now, status) {
-        assert.equal(now, 1234)
-        assert.deepEqual(status, { repo1: 'repo 1 data', repo2: 'repo 2 data' })
-        log.push('render index')
-      }
-      renderer._setLastRender = async function(now) {
-        assert.equal(now, 1234)
-        log.push('set last render')
+      let renderEntered = 0
+      let renderExited = 0
+      let renderCanResolve = false
+
+      renderer._render = async function() {
+        renderEntered++
+        await waitUntil(() => renderCanResolve)
+        this.rendering = false
+        renderExited++
       }
 
-      await renderer.render(1234)
+      renderer.render()
+      await wait(20)
 
-      assert.deepEqual(log, [
-        'read status',
-        'render with repo1 repo 1 data',
-        'render with repo2 repo 2 data',
-        'render index',
-        'set last render'
-      ])
+      renderer.render()
+      await wait(20)
+
+      renderer.render()
+      await wait(20)
+
+      renderer.render()
+      await wait(20)
+
+      renderCanResolve = true
+      await waitUntil(() => renderExited === renderEntered)
+
+      assert.equal(renderEntered, 1)
+      assert.ok(renderer.shouldRefresh)
+
+      renderer.render()
+      await wait(20)
+      await waitUntil(() => renderExited === renderEntered)
+
+      assert.equal(renderEntered, 2)
     })
   })
 })

--- a/test/unit/status/render.test.js
+++ b/test/unit/status/render.test.js
@@ -49,6 +49,7 @@ describe('unit | status/render', function() {
 
       assert.isFunction(renderer.indexTemplate)
       assert.isFunction(renderer.buildTemplate)
+      assert.isFunction(renderer.buildredirTemplate)
       assert.isFunction(renderer.repoTemplate)
     })
   })
@@ -216,6 +217,39 @@ describe('unit | status/render', function() {
       })
 
       assert.notOk(templateData.is_running)
+    })
+
+    it('renders redirection template when build has extra.oldBuildID', async function() {
+      let renderer = new Renderer()
+      let templateData
+
+      renderer.buildTemplate = function() {}
+      renderer.buildredirTemplate = function(data) {
+        templateData = data
+        return 'redirection page'
+      }
+
+      mock('db', {
+        async getSteps() {
+          return []
+        }
+      })
+
+      await renderer._renderBuild({ name: 'repo' }, {
+        id: 100,
+        data: 'some build data',
+        status: 'cancelled',
+        extra: {
+          oldBuildID: 'repo#12345'
+        }
+      })
+
+      assert.deepEqual(templateData, { id: 100 })
+
+      assert.equal(
+        await readFile(resolve(statusDirectory, 'repo/12345.html')),
+        'redirection page'
+      )
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2403,6 +2403,11 @@ nan@^2.11.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
   integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
 
+nan@^2.12.1:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -3419,6 +3424,29 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+sql-template-strings@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/sql-template-strings/-/sql-template-strings-2.2.2.tgz#3f11508a25addfce217a3042a9d300c3193b96ff"
+  integrity sha1-PxFQiiWt384hejBCqdMAwxk7lv8=
+
+sqlite3@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.1.0.tgz#e051fb9c133be15726322a69e2e37ec560368380"
+  integrity sha512-RvqoKxq+8pDHsJo7aXxsFR18i+dU2Wp5o12qAJOV5LNcDt+fgJsc2QKKg3sIRfXrN9ZjzY1T7SNe/DFVqAXjaw==
+  dependencies:
+    nan "^2.12.1"
+    node-pre-gyp "^0.11.0"
+    request "^2.87.0"
+
+sqlite@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/sqlite/-/sqlite-3.0.3.tgz#3f519cfc599ffa3270d76f3567bf2abb2ac18742"
+  integrity sha512-DpofdtBibbiOObtdADGZYE6bvnLpjRG4ut/MDTDau2nK40htOLj1E0c55aOkvbnRVqQ0ZPtjj7PJuKKyS0Ypww==
+  dependencies:
+    sqlite3 "^4.0.0"
+  optionalDependencies:
+    sql-template-strings "^2.2.2"
 
 sshpk@^1.7.0:
   version "1.16.0"


### PR DESCRIPTION
Refs https://people-doc.atlassian.net/browse/JS-159

Closes #26

Sorry this is quite a huge PR, but there was no way to do this in small increments.

Peon now stores its data in a sqlite db instead of using JSON files. That makes the code much more readable, makes read/writes of status data more resilient (and concurrent-proof) and paves the way to replace the statically generated status page with an API + ember app.