### PR TITLE
Feat: cleanup local builds

### DIFF
--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -83,7 +83,7 @@ class Build {
         (updateOutput) => this._readPeonConfig(updateOutput)
       )
 
-      let { env, peonConfig } = this
+      let { peonConfig } = this
 
       if (peonConfig.cache && peonConfig.cache.length) {
         await this._runStep(
@@ -106,23 +106,12 @@ class Build {
         )
       }
 
-      await this._runStep(
+      let deployData = await this._runStep(
         'deploy',
         (updateOutput) => this._deploy(updateOutput)
       )
 
-      let {
-        destination: { absoluteUrl },
-        pathInDestination
-      } = this
-
-      // We cannot use path.join here because of the protocol:// prefix
-      if (!absoluteUrl.endsWith('/')) {
-        absoluteUrl = `${absoluteUrl}/`
-      }
-      await status.finishBuild(buildId, 'success', {
-        outputURL: `${absoluteUrl}${env.evaluate(pathInDestination)}`
-      })
+      await status.finishBuild(buildId, 'success', deployData)
     } catch(e) {
       if (e instanceof CancelBuild) {
         this.info(`cancelled build, ${e.message}`)
@@ -500,7 +489,18 @@ class Build {
       await remove(tmpDir)
     }
 
-    this.info(`built ${sha} successfully`)
+    this.info(`deployed ${sha} successfully`)
+
+    let { absoluteUrl } = destination
+
+    if (!absoluteUrl.endsWith('/')) {
+      absoluteUrl = `${absoluteUrl}/`
+    }
+
+    return {
+      outputURL: `${absoluteUrl}${evaluatedPathInDest}`,
+      localDirectory: isRemote ? null : destDir.replace(/\/$/, '')
+    }
   }
 }
 

--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -68,27 +68,48 @@ class Build {
     this.info(`building commit ${sha}`)
 
     try {
-      await this._runStep('update repository', () => this._updateRepository())
-      await this._runStep('create workspace', () => this._createWorkspace())
-      await this._runStep('read .peon.yml', () => this._readPeonConfig())
+      await this._runStep(
+        'update repository',
+        (updateOutput) => this._updateRepository(updateOutput)
+      )
+
+      await this._runStep(
+        'create workspace',
+        (updateOutput) => this._createWorkspace(updateOutput)
+      )
+
+      await this._runStep(
+        'read .peon.yml',
+        (updateOutput) => this._readPeonConfig(updateOutput)
+      )
 
       let { env, peonConfig } = this
 
       if (peonConfig.cache && peonConfig.cache.length) {
-        await this._runStep('restore cache', () => this._restoreCache())
+        await this._runStep(
+          'restore cache',
+          (updateOutput) => this._restoreCache(updateOutput)
+        )
       }
 
       for (let command of peonConfig.commands) {
-        await this._runStep(`run ${command}`, (updateOutput) =>
-          this._runCommand(command, updateOutput)
+        await this._runStep(
+          `run ${command}`,
+          (updateOutput) => this._runCommand(command, updateOutput)
         )
       }
 
       if (peonConfig.cache && peonConfig.cache.length) {
-        await this._runStep('save cache', () => this._saveCache())
+        await this._runStep(
+          'save cache',
+          (updateOutput) => this._saveCache(updateOutput)
+        )
       }
 
-      await this._runStep('deploy', () => this._deploy())
+      await this._runStep(
+        'deploy',
+        (updateOutput) => this._deploy(updateOutput)
+      )
 
       let {
         destination: { absoluteUrl },
@@ -134,9 +155,9 @@ class Build {
     this.debug(`running step: ${stepName}`)
     await updateStep('running')
 
-    let output
+    let returnValue
     try {
-      output = await step(updateOutput)
+      returnValue = await step(updateOutput)
       await updateQueue.join()
     } catch(e) {
       await updateQueue.join()
@@ -153,7 +174,8 @@ class Build {
       }
     }
 
-    await updateStep('success', output)
+    await updateStep('success')
+    return returnValue
   }
 
   async _updateRepository() {
@@ -313,7 +335,7 @@ class Build {
     )
   }
 
-  async _restoreCache() {
+  async _restoreCache(updateOutput) {
     let { repoName, workspace, peonConfig } = this
     let { cache } = lookup()
 
@@ -324,15 +346,17 @@ class Build {
         peonConfig.cache
       )
 
-      return restoredPaths.length
-        ? `restored paths ${restoredPaths.join(', ')}`
-        : 'found nothing to restore'
+      updateOutput(
+        restoredPaths.length
+          ? `restored paths ${restoredPaths.join(', ')}`
+          : 'found nothing to restore'
+      )
     } catch(e) {
       throw new BuildWarning(e)
     }
   }
 
-  async _saveCache() {
+  async _saveCache(updateOutput) {
     let { repoName, workspace, peonConfig } = this
     let { cache } = lookup()
 
@@ -342,9 +366,12 @@ class Build {
         workspace,
         peonConfig.cache
       )
-      return savedPaths.length
-        ? `saved paths ${savedPaths.join(', ')}`
-        : 'found nothing to save'
+
+      updateOutput(
+        savedPaths.length
+          ? `saved paths ${savedPaths.join(', ')}`
+          : 'found nothing to save'
+      )
     } catch(e) {
       throw new BuildWarning(e)
     }
@@ -376,7 +403,7 @@ class Build {
     })
 
     await promise
-    return outputLines.join('')
+    updateOutput(outputLines.join(''))
   }
 
   async _deploy() {

--- a/lib/build/dispatcher.js
+++ b/lib/build/dispatcher.js
@@ -25,22 +25,24 @@ class Dispatcher {
       return
     }
 
-    let { status, Build } = lookup()
-    let buildId = await status.startBuild(
-      repoConfig.url,
-      repoConfig.name,
-      repoConfig.refMode,
-      repoConfig.ref,
-      payload.head_commit.id
-    )
+    if (payload.head_commit) {
+      let { status, Build } = lookup()
+      let buildId = await status.startBuild(
+        repoConfig.url,
+        repoConfig.name,
+        repoConfig.refMode,
+        repoConfig.ref,
+        payload.head_commit.id
+      )
 
-    let build = new Build(buildId, payload, repoConfig)
+      let build = new Build(buildId, payload, repoConfig)
 
-    logger.debug(`enqueuing build ${buildId}`, {
-      module: `dispatcher/${repoConfig.name}`
-    })
+      logger.debug(`enqueuing build ${buildId}`, {
+        module: `dispatcher/${repoConfig.name}`
+      })
 
-    this.queue.run(() => build.build())
+      this.queue.run(() => build.build())
+    }
   }
 
   findRepository(eventType, payload) {

--- a/lib/build/dispatcher.js
+++ b/lib/build/dispatcher.js
@@ -42,6 +42,21 @@ class Dispatcher {
       })
 
       this.queue.run(() => build.build())
+    } else {
+      // No head_commit: this is a deleted ref
+
+      let { status } = lookup()
+
+      logger.debug(
+        `enqueuing cleanup job for ${repoConfig.refMode} ${repoConfig.ref}`,
+        { module: `dispatcher/${repoConfig.name}` }
+      )
+
+      this.queue.run(() => status.cleanupLocalBuilds(
+        repoConfig.name,
+        repoConfig.refMode,
+        repoConfig.ref
+      ))
     }
   }
 

--- a/lib/status/db.js
+++ b/lib/status/db.js
@@ -268,6 +268,15 @@ class Database {
     )).map(parseExtra)
   }
 
+  async getBuildsFor({ repoName, refMode, ref }) {
+    return (await this._all(
+      SQL`SELECT b.id, b.ref_type, b.ref, b.sha, b.enqueued, b.updated, b.start,
+                 b.end, b.status, b.extra
+          FROM Build b JOIN Repo r ON b.repo_id = r.id
+          WHERE r.name = ${repoName} AND b.ref_type = ${refMode} AND b.ref = ${ref}`
+    )).map(parseExtra)
+  }
+
   async getStaleBuilds() {
     return await this._all(
       SQL`SELECT id FROM Build
@@ -305,7 +314,11 @@ class Database {
       SQL`SELECT status, start FROM Build WHERE id = ${id}`
     )
 
-    let query = SQL`UPDATE Build SET status = ${status}, updated = ${now}`
+    let query = SQL`UPDATE Build SET status = ${status}`
+
+    if (status !== 'cleaned') {
+      query.append(SQL`, updated = ${now}`)
+    }
 
     if (!build.start && status !== 'cancelled' && status !== 'failed') {
       query.append(SQL`, start = ${now}`)

--- a/lib/status/render.js
+++ b/lib/status/render.js
@@ -40,7 +40,8 @@ function augmentBuild(build, additionalInfo = {}) {
     {
       build_link: `${build.id}.html`,
       queue_time: build.start ? build.start - build.enqueued : null,
-      run_time: build.end ? build.end - build.start : null
+      run_time: build.end ? build.end - build.start : null,
+      is_cleaned: build.status === 'cleaned'
     },
     additionalInfo,
     build

--- a/lib/status/status.js
+++ b/lib/status/status.js
@@ -1,3 +1,4 @@
+const { remove } = require('fs-extra')
 const { lookup, registerForTest, registerLazy } = require('../injections')
 
 class Status {
@@ -30,6 +31,34 @@ class Status {
 
       await db.updateBuild({ id, status: 'cancelled' })
       githubStatus.update(id, 'error', 'Peon stale build was aborted')
+    }
+  }
+
+  async cleanupLocalBuilds(repoName, refMode, ref) {
+    let { logger } = this
+    let { db } = lookup()
+
+    for (let { id, status, extra } of await db.getBuildsFor({ repoName, refMode, ref })) {
+      if (status !== 'success' || !extra) {
+        continue
+      }
+
+      let { localDirectory } = extra
+
+      if (!localDirectory) {
+        continue
+      }
+
+      logger.debug(
+        `removing local build #${id} at ${localDirectory}`,
+        { module: 'status' }
+      )
+
+      await remove(localDirectory)
+      await db.updateBuild({
+        id,
+        status: 'cleaned'
+      })
     }
   }
 

--- a/templates/build.hbs
+++ b/templates/build.hbs
@@ -30,7 +30,11 @@ Building SHA {{sha}} on {{ref_type}} {{ref}}<br>
 Enqueued at {{date enqueued}}<br>
 {{#if start}}Started at {{date start}}<br>{{/if}}
 {{#if end}}Finished at {{date end}}<br>{{/if}}
-{{#if extra.outputURL}}<a href="{{extra.outputURL}}" target="_blank">Link to deployed build output</a><br>{{/if}}
+{{#if is_cleaned}}
+  Build was cleaned because {{ref_type}} {{ref}} was deleted<br>
+{{else}}
+  {{#if extra.outputURL}}<a href="{{extra.outputURL}}" target="_blank">Link to deployed build output</a><br>{{/if}}
+{{/if}}
 
 {{#each steps}}
   <h2 class="status-{{status}}">{{description}} <span class="duration">({{time duration}})</span></h2>

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -82,9 +82,11 @@
           {{status}}
         </td>
         <td>
-          {{#if extra.outputURL}}
-            <a href="{{extra.outputURL}}" target="_blank">Build output</a>
-          {{/if}}
+          {{#unless is_cleaned}}
+            {{#if extra.outputURL}}
+              <a href="{{extra.outputURL}}" target="_blank">Build output</a>
+            {{/if}}
+          {{/unless}}
         </td>
       </tr>
     {{/each}}

--- a/templates/repo.hbs
+++ b/templates/repo.hbs
@@ -80,9 +80,11 @@
         {{status}}
       </td>
       <td>
-        {{#if extra.outputURL}}
-          <a href="{{extra.outputURL}}" target="_blank">Build output</a>
-        {{/if}}
+        {{#unless is_cleaned}}
+          {{#if extra.outputURL}}
+            <a href="{{extra.outputURL}}" target="_blank">Build output</a>
+          {{/if}}
+        {{/unless}}
       </td>
     </tr>
   {{/each}}

--- a/test/unit/build/dispatcher.test.js
+++ b/test/unit/build/dispatcher.test.js
@@ -148,14 +148,29 @@ describe('unit | build/dispatcher', function() {
       assert.notOk(startBuildCalled)
     })
 
-    it('does not do anything when payload has no head_commit', async function() {
-      let startBuildCalled
+    it('starts a cleanup job and enqueues it when findRepository returns stuff and payload has no head_commit', async function() {
+      let startBuildCalled, cleanupArgs, queuedFunction
 
       mock('status', {
         startBuild() {
           startBuildCalled = true
         }
       })
+
+      mock('status', {
+        cleanupLocalBuilds() {
+          cleanupArgs = [...arguments]
+        }
+      })
+
+      mock(
+        'Queue',
+        class Queue {
+          run(fun) {
+            queuedFunction = fun
+          }
+        }
+      )
 
       let dispatcher = new Dispatcher()
       dispatcher.findRepository = () => {
@@ -169,6 +184,9 @@ describe('unit | build/dispatcher', function() {
       await dispatcher.dispatch('push', {})
 
       assert.notOk(startBuildCalled)
+      assert.ok(queuedFunction)
+      await queuedFunction()
+      assert.deepEqual(cleanupArgs, ['repo', 'branch', 'mybranch'])
     })
 
     it('starts a build and enqueues it when findRepository returns stuff', async function() {

--- a/test/unit/build/dispatcher.test.js
+++ b/test/unit/build/dispatcher.test.js
@@ -148,6 +148,29 @@ describe('unit | build/dispatcher', function() {
       assert.notOk(startBuildCalled)
     })
 
+    it('does not do anything when payload has no head_commit', async function() {
+      let startBuildCalled
+
+      mock('status', {
+        startBuild() {
+          startBuildCalled = true
+        }
+      })
+
+      let dispatcher = new Dispatcher()
+      dispatcher.findRepository = () => {
+        return {
+          name: 'repo',
+          url: 'git@example.com:org/repo',
+          refMode: 'branch',
+          ref: 'mybranch'
+        }
+      }
+      await dispatcher.dispatch('push', {})
+
+      assert.notOk(startBuildCalled)
+    })
+
     it('starts a build and enqueues it when findRepository returns stuff', async function() {
       let buildCtorArgs, buildCalled, startBuildArgs, queuedFunction
 

--- a/test/unit/status/render.test.js
+++ b/test/unit/status/render.test.js
@@ -90,6 +90,7 @@ describe('unit | status/render', function() {
         start: 1000,
         end: 2000,
 
+        is_cleaned: false,
         is_running: false,
         queue_time: 500,
         run_time: 1000,
@@ -304,7 +305,8 @@ describe('unit | status/render', function() {
             updated: now + 1,
             run_time: null,
             build_link: '2.html',
-            queue_time: null
+            queue_time: null,
+            is_cleaned: false
           },
           {
             id: 1,
@@ -314,7 +316,8 @@ describe('unit | status/render', function() {
             updated: now,
             run_time: null,
             build_link: '1.html',
-            queue_time: null
+            queue_time: null,
+            is_cleaned: false
           }
         ],
         now,


### PR DESCRIPTION
Rewrite of #35 

Closes #18 

Note: this PR is better reviewed 1 commit at a time. Here is a rundown of what each commit does.

1. Until now, build steps had two ways of reporting output: calling the updateOutput function passed to them as an argument, or returning a value. This commit removes the latter. Steps are rewritten to always call updateOutput.
2. This commit is the reason for the change above. Previously the build method was generating the extra data passed to updateBuild (containing the build URL). Now this data is generated and returned by the deploy step: this allows the deploy step to also include the local directory where the build is deployed when the destination is local.
3. We ignore webhook payloads without a head_commit and don't run a build. This commit is not very useful because...
4. ...without a head_commit, we now cleanup previous builds with that ref. This uses the local directory saved by local builds and removes them.
5. This commit adds a is_cleaned marker to builds when rendering them so that we can hide the link to the build output.
