### PR TITLE
feat: add retrigger build button to status pages (JS-825)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ The configuration file contains the following keys:
     on the public endpoint to this port.
   - `webhooks.secret`: set it to something secret that you will configure on
     your repositories on Github.
-  - `webhooks.url`: optional, sets the URL where webhook payloads for manual job
-    retriggers from status pages should be sent.
+  - `webhooks.url`: (optional) URL where webhook payloads, for manual job
+    retriggers from status pages, should be sent.
 
 - **Build output destinations configuration:** configure destinations where Peon
   will store build outputs (using rsync). Destinations can be local or remote.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The configuration file contains the following keys:
     on the public endpoint to this port.
   - `webhooks.secret`: set it to something secret that you will configure on
     your repositories on Github.
+  - `webhooks.url`: optional, sets the URL where webhook payloads for manual job
+    retriggers from status pages should be sent.
 
 - **Build output destinations configuration:** configure destinations where Peon
   will store build outputs (using rsync). Destinations can be local or remote.

--- a/config.sample.json
+++ b/config.sample.json
@@ -13,7 +13,8 @@
   "webhooks": {
     "enabled": true,
     "port": 1234,
-    "secret": "peon-super-secret"
+    "secret": "peon-super-secret",
+    "url": "https://my.host/peon-webhooks"
   },
 
   "git": {

--- a/lib/status/render.js
+++ b/lib/status/render.js
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 
+const { createHmac } = require('crypto')
 const { dirname, resolve } = require('path')
 const { ensureDir, readFile, writeFile } = require('fs-extra')
 
@@ -105,7 +106,10 @@ class Renderer {
     let { logger, buildTemplate, buildredirTemplate } = this
 
     let {
-      config: { statusDirectory },
+      config: {
+        statusDirectory,
+        webhooks: { url: webhooksUrl, secret: webhooksSecret }
+      },
       db
     } = lookup()
 
@@ -116,11 +120,41 @@ class Renderer {
     let steps = await db.getSteps(build.id)
     let outputFile = resolve(statusDirectory, `${build.id}.html`)
 
+    let retriggerData = null
+    let isRunning = ['pending', 'running'].indexOf(build.status) !== -1
+
+    if (webhooksUrl && !isRunning) {
+      let payload = JSON.stringify({
+        head_commit: {
+          id: build.sha
+        },
+        ref: `refs/${build.ref_type === 'branch' ? 'heads' : 'tags'}/${build.ref}`,
+        repository: {
+          name: repo.name,
+          ssh_url: repo.url
+        }
+      })
+
+      let signature = `sha1=${createHmac('sha1', webhooksSecret).update(payload).digest('hex')}`
+
+      retriggerData = {
+        url: webhooksUrl,
+        headers: JSON.stringify({
+          'Content-Type': 'application/json',
+          'x-github-delivery': 'manual-peon-retrigger',
+          'x-github-event': 'push',
+          'x-hub-signature': signature
+        }),
+        payload: `'${payload.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+      }
+    }
+
     let buildData = augmentBuild(build, {
       repo_link: `${repo.name}.html`,
       repo_name: repo.name,
       steps: steps.map((s) => augmentStep(s)),
-      is_running: ['pending', 'running'].indexOf(build.status) !== -1
+      is_running: isRunning,
+      retrigger: retriggerData
     })
 
     try {

--- a/lib/watch/webhooks.js
+++ b/lib/watch/webhooks.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const { json } = require('body-parser')
+const cors = require('cors')
 const GithubWebHook = require('express-github-webhook')
 
 const { lookup, register } = require('../injections')
@@ -31,6 +32,7 @@ class WebhookServer {
     if (!this._app) {
       let { logger, webhookHandler } = this
       let app = express()
+      app.use(cors())
       app.use(json())
       app.use(webhookHandler)
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@octokit/rest": "^16.17.0",
     "body-parser": "^1.18.3",
     "child-process-promise": "^2.2.1",
+    "cors": "^2.8.5",
     "express": "^4.16.4",
     "express-github-webhook": "^1.0.6",
     "fs-extra": "^7.0.1",

--- a/templates/build.hbs
+++ b/templates/build.hbs
@@ -36,6 +36,45 @@ Enqueued at {{date enqueued}}<br>
   {{#if extra.outputURL}}<a href="{{extra.outputURL}}" target="_blank">Link to deployed build output</a><br>{{/if}}
 {{/if}}
 
+{{#if retrigger}}
+  <br>
+  <button id="retrigger">Retrigger build</button>
+  <script>
+    (function() {
+      let button = document.getElementById('retrigger')
+
+      async function retrigger() {
+        let response
+        button.disabled = true
+
+        try {
+          response = await fetch('{{retrigger.url}}', {
+            method: 'POST',
+            headers: {{{retrigger.headers}}},
+            body: {{{retrigger.payload}}}
+          })
+
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+          }
+        } catch(e) {
+          console.error('Retrigger error:', e)
+          alert('Build retrigger failed, please check the console and Peon logs')
+          button.disabled = false
+          return
+        }
+
+        location.href = "{{repo_link}}"
+      }
+
+      button.addEventListener('click', function(e) {
+        retrigger()
+        e.preventDefault()
+      })
+    })()
+  </script>
+{{/if}}
+
 {{#each steps}}
   <h2 class="status-{{status}}">{{description}} <span class="duration">({{time duration}})</span></h2>
   {{#if output}}

--- a/test/config.json
+++ b/test/config.json
@@ -1,4 +1,5 @@
 {
+  "webhooks": {},
   "logger": {
     "level": "emerg"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,6 +687,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cross-spawn@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -2589,7 +2597,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -3844,7 +3852,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=


### PR DESCRIPTION
This PR adds a "retrigger build" button to status pages.

The way it works is as follows:
- config should specify a public-ish URL for webhooks, that is a URL that is reachable from a network where peon status pages are reachable (it does NOT have to be the "fully public" webhook URL, a URL merely reachable from the VPN is enough)
- when that config is specified, build pages include a button and a small script to send a POST request to the webhook endpoint, that includes a valid webhook payload, using the branch/tag + sha from the build
- when a user clicks that button, the request is sent, and on success they are redirected to the repo status page (that with all builds for the repository), which will after a few autorefresh show the new build running

Note: when receiving a push event, peon webhook handler always checks out the specified SHA, NOT the corresponding branch or tag.